### PR TITLE
fix: remove progress bar CSS transition to prevent visual desync

### DIFF
--- a/src/library/components/TabViewer.svelte
+++ b/src/library/components/TabViewer.svelte
@@ -1855,7 +1855,7 @@
 			<!-- Track background -->
 			<div class="absolute inset-0 bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
 				<!-- Playback progress fill -->
-				<div class="absolute inset-y-0 left-0 bg-violet-500 transition-[width] duration-100" style="width: {progress}%" />
+				<div class="absolute inset-y-0 left-0 bg-violet-500" style="width: {progress}%" />
 
 				<!-- Hover preview -->
 				{#if showProgressTooltip && hoverProgress > progress && !isDraggingLoop}


### PR DESCRIPTION
## Summary

- Remove `transition-[width] duration-100` from the progress bar fill element
- The CSS transition amplified stale position events from alphaTab's internal seek (clicking on sheet music), causing the bar to visually stick at the wrong position
- Position events fire at ~200Hz, so the bar is already smooth without the transition

## Context

Follow-up to #88. When clicking directly on the sheet music, alphaTab fires brief stale position events. Without CSS transition these are imperceptible; with transition they created persistent visual desync.

## Test plan

- [ ] Play song, click on beats in the sheet — progress bar stays in sync
- [ ] Progress bar still looks smooth during normal playback
- [ ] Seek via timeline click still works cleanly (from #88)