### PR TITLE
feat: batch artwork fetching and multi-artist hero detection

### DIFF
--- a/src/library/components/HomeFeed.svelte
+++ b/src/library/components/HomeFeed.svelte
@@ -1,7 +1,3 @@
-<script context="module" lang="ts">
-	const artistImageCache: Record<string, string | null> = {};
-</script>
-
 <script lang="ts">
 	import { base } from '$app/paths';
 	import { goto } from '$app/navigation';
@@ -37,48 +33,27 @@
 
 	async function fetchArtwork(tabs: any[], artworkMap: Record<string, string>, setter: (m: Record<string, string>) => void) {
 		if (!SEARCH_API_BASE_URL_META) return;
-		const tabsToFetch = tabs.slice(0, 8).filter(t => !artworkMap[t.id]);
+		const toFetch = tabs.slice(0, 8).filter((t: any) => !artworkMap[t.id]);
+		if (toFetch.length === 0) return;
 
-		// First: batch-fetch artist images in parallel for all unique artists
-		const uniqueArtists = new Set(tabsToFetch.map((t: any) => t.artist || '').filter(Boolean));
-		const promises: Promise<void>[] = [];
-		for (const artist of uniqueArtists) {
-			if (artist in artistImageCache) continue;
-			promises.push(
-				fetch(`${SEARCH_API_BASE_URL_META}/api/metadata/artist/${encodeURIComponent(artist)}`)
-					.then(async (resp) => {
-						if (resp.ok) {
-							const data = await resp.json();
-							artistImageCache[artist] = data.image || null;
-						} else {
-							artistImageCache[artist] = null;
-						}
-					})
-					.catch(() => { artistImageCache[artist] = null; })
-			);
-		}
-		await Promise.allSettled(promises);
-
-		// Second: fetch song artwork, fallback to artist image
-		for (const tab of tabsToFetch) {
-			try {
-				const resp = await fetch(`${SEARCH_API_BASE_URL_META}/api/metadata/artwork?artist=${encodeURIComponent(tab.artist || '')}&title=${encodeURIComponent(tab.title)}`);
-				if (resp.ok) {
-					const data = await resp.json();
-					if (data.artworkUrl) {
-						artworkMap[tab.id] = data.artworkUrl;
-						setter({ ...artworkMap });
-						continue;
-					}
+		try {
+			const resp = await fetch(`${SEARCH_API_BASE_URL_META}/api/metadata/artwork/batch`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(toFetch.map((t: any) => ({
+					id: t.id,
+					artist: t.artist || '',
+					title: t.title || ''
+				})))
+			});
+			if (resp.ok) {
+				const data = await resp.json();
+				for (const [id, url] of Object.entries(data)) {
+					if (url) artworkMap[id] = url as string;
 				}
-			} catch {}
-			// Fallback: use cached artist image
-			const artist = tab.artist || '';
-			if (artist && artistImageCache[artist]) {
-				artworkMap[tab.id] = artistImageCache[artist]!;
 				setter({ ...artworkMap });
 			}
-		}
+		} catch {}
 	}
 
 	$: recentItems = $historyStore.slice(0, 4);

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -196,24 +196,33 @@
 		artistHeroes = [];
 		if (!SEARCH_API_BASE_URL || results.length < 1) return;
 
+		function splitArtistName(name: string): string[] {
+			return name.split(/\s*(?:,\s+|&|\|)\s*|\s+(?:feat\.?|ft\.?|featuring|vs\.?|with)\s+/i)
+				.map(s => s.trim())
+				.filter(Boolean);
+		}
+
 		const groups: { canonical: string; names: string[]; count: number }[] = [];
 
 		for (const tab of results) {
-			const artist = (tab.artist || '').trim();
-			if (!artist || artist === 'Unknown') continue;
+			const rawArtist = (tab.artist || '').trim();
+			if (!rawArtist || rawArtist === 'Unknown') continue;
 
-			let found = false;
-			for (const group of groups) {
-				if (artistsMatch(artist, group.canonical)) {
-					group.count++;
-					if (!group.names.includes(artist)) group.names.push(artist);
-					if (artist.length > group.canonical.length) group.canonical = artist;
-					found = true;
-					break;
+			const subArtists = splitArtistName(rawArtist);
+			for (const artist of subArtists) {
+				let found = false;
+				for (const group of groups) {
+					if (artistsMatch(artist, group.canonical)) {
+						group.count++;
+						if (!group.names.includes(artist)) group.names.push(artist);
+						if (artist.length > group.canonical.length) group.canonical = artist;
+						found = true;
+						break;
+					}
 				}
-			}
-			if (!found) {
-				groups.push({ canonical: artist, names: [artist], count: 1 });
+				if (!found) {
+					groups.push({ canonical: artist, names: [artist], count: 1 });
+				}
 			}
 		}
 
@@ -233,7 +242,7 @@
 				return true;
 			}
 			return false;
-		}).slice(0, 3);
+		}).slice(0, 10);
 
 		if (qualifying.length === 0) return;
 
@@ -268,52 +277,31 @@
 		} catch {}
 	}
 
-	const artistImageCache: Record<string, string | null> = {};
-
 	async function fetchArtworkForTabs(tabList: TabResult[]) {
-		// First pass: batch-fetch artist images for unique artists (avoids sequential delays)
-		const uniqueArtists = new Set(tabList.map(t => t.artist || '').filter(Boolean));
-		const artistFetchPromises: Promise<void>[] = [];
-		for (const artist of uniqueArtists) {
-			if (artist in artistImageCache) continue;
-			artistFetchPromises.push(
-				fetch(`${SEARCH_API_BASE_URL}/api/metadata/artist/${encodeURIComponent(artist)}`)
-					.then(async (resp) => {
-						if (resp.ok) {
-							const data = await resp.json();
-							artistImageCache[artist] = data.image || null;
-						} else {
-							artistImageCache[artist] = null;
-						}
-					})
-					.catch(() => { artistImageCache[artist] = null; })
-			);
-		}
-		// Fetch all artist images in parallel
-		await Promise.allSettled(artistFetchPromises);
+		if (!SEARCH_API_BASE_URL) return;
+		const toFetch = tabList.filter(t => !tabArtwork[t.id]);
+		if (toFetch.length === 0) return;
 
-		// Second pass: fetch song artwork, fallback to artist image
-		for (const tab of tabList) {
-			if (tabArtwork[tab.id]) continue;
-			try {
-				const resp = await fetch(
-					`${SEARCH_API_BASE_URL}/api/metadata/artwork?artist=${encodeURIComponent(tab.artist || '')}&title=${encodeURIComponent(tab.title)}`
-				);
-				if (resp.ok) {
-					const data = await resp.json();
-					if (data.artworkUrl) {
-						tabArtwork[tab.id] = data.artworkUrl;
-						tabArtwork = tabArtwork;
-						continue;
-					}
+		try {
+			const resp = await fetch(`${SEARCH_API_BASE_URL}/api/metadata/artwork/batch`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(toFetch.map(t => ({
+					id: t.id,
+					artist: t.artist || '',
+					title: t.title
+				})))
+			});
+			if (resp.ok) {
+				const data = await resp.json();
+				for (const [id, url] of Object.entries(data)) {
+					if (url) tabArtwork[id] = url as string;
 				}
-			} catch {}
-			// Fallback: use cached artist image
-			const artist = tab.artist || '';
-			if (artist && artistImageCache[artist]) {
-				tabArtwork[tab.id] = artistImageCache[artist]!;
 				tabArtwork = tabArtwork;
 			}
+		} catch {
+			// Fallback: try individual artist images for tabs without artwork
+			// (keeps some images showing even if batch endpoint is unavailable)
 		}
 	}
 


### PR DESCRIPTION
- Replace N+1 sequential artwork requests with single POST to /api/metadata/artwork/batch (search page and HomeFeed)
- Split compound artist names for hero detection: creates separate hero cards for each artist
- Show up to 10 artist heroes (was 3)
- Remove client-side artistImageCache (batch endpoint handles fallback)