### PR TITLE
feat: unified artwork, UX polish, soundfont improvements

### DIFF
--- a/src/library/components/Header.svelte
+++ b/src/library/components/Header.svelte
@@ -14,6 +14,7 @@
 	const dispatch = createEventDispatcher();
 	let mobileSearchOpen = false;
 	let searchBar: SearchBar;
+	let scrolled = false;
 
 	// Check if we're on the search page
 	$: isOnSearch = $page.url.pathname.includes('/search');
@@ -45,9 +46,9 @@
 	}
 </script>
 
-<svelte:window on:keydown={handleGlobalKeydown} />
+<svelte:window on:keydown={handleGlobalKeydown} on:scroll={() => { scrolled = window.scrollY > 0; }} />
 
-<header class="sticky top-0 z-[100] bg-white dark:bg-black border-b border-neutral-300 dark:border-neutral-700">
+<header class="sticky top-0 z-[100] bg-white dark:bg-black border-b border-neutral-300 dark:border-neutral-700 transition-shadow duration-200 {scrolled ? 'shadow-sm' : ''}">
 	<div class="flex items-center h-14 px-4 gap-2 sm:gap-3">
 		<!-- Logo (always visible, including name on mobile) -->
 		<a href="{base}/" class="flex items-center gap-1 flex-shrink-0" aria-label="Home">

--- a/src/library/components/HomeFeed.svelte
+++ b/src/library/components/HomeFeed.svelte
@@ -19,6 +19,7 @@
 	let recommended: any[] = [];
 	let discover: any[] = [];
 	let stats: { totalTabs?: number; totalArtists?: number } = {};
+	let recentArtwork: Record<string, string> = {};
 
 	let loadingRecommended = true;
 	let loadingDiscover = true;
@@ -27,36 +28,22 @@
 	let dragActive = false;
 	let fileInput: HTMLInputElement;
 
-	const SEARCH_API_BASE_URL_META = import.meta.env.VITE_SEARCH_API_BASE_URL;
+	import { fetchArtworkBatch } from '../utils/artwork';
+
 	let recommendedArtwork: Record<string, string> = {};
 	let discoverArtwork: Record<string, string> = {};
-
+	
 	async function fetchArtwork(tabs: any[], artworkMap: Record<string, string>, setter: (m: Record<string, string>) => void) {
-		if (!SEARCH_API_BASE_URL_META) return;
-		const toFetch = tabs.slice(0, 8).filter((t: any) => !artworkMap[t.id]);
-		if (toFetch.length === 0) return;
-
-		try {
-			const resp = await fetch(`${SEARCH_API_BASE_URL_META}/api/metadata/artwork/batch`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(toFetch.map((t: any) => ({
-					id: t.id,
-					artist: t.artist || '',
-					title: t.title || ''
-				})))
-			});
-			if (resp.ok) {
-				const data = await resp.json();
-				for (const [id, url] of Object.entries(data)) {
-					if (url) artworkMap[id] = url as string;
-				}
-				setter({ ...artworkMap });
-			}
-		} catch {}
+		const updated = await fetchArtworkBatch(tabs.slice(0, 12), artworkMap);
+		setter(updated);
 	}
 
 	$: recentItems = $historyStore.slice(0, 4);
+	let recentArtworkFetched = false;
+	$: if (recentItems.length > 0 && !recentArtworkFetched) {
+		recentArtworkFetched = true;
+		fetchArtworkBatch(recentItems, recentArtwork).then(m => { recentArtwork = m; });
+	}
 
 	function getArtists(): string[] {
 		const history = get(historyStore);
@@ -200,7 +187,7 @@
 	});
 </script>
 
-<div class="py-6 min-h-[calc(100vh-3.5rem)]">
+<div class="py-6">
 	<!-- Top row: Import + Recently Viewed side by side on desktop, stacked on mobile -->
 	<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
 		<!-- Import card (1 col on desktop) -->
@@ -245,7 +232,7 @@
 					</span>
 					<a href="{base}/collection" class="text-[11px] text-violet-500 hover:underline">See all</a>
 				</div>
-				<div class="divide-y divide-neutral-100 dark:divide-neutral-800/50 max-h-[220px] overflow-y-auto">
+				<div class="divide-y divide-neutral-100 dark:divide-neutral-800/50 max-h-[30vh] overflow-y-auto">
 					{#each recentItems as item}
 						<ResultCard
 							id={item.id}
@@ -254,6 +241,7 @@
 							source={item.source}
 							type={item.type || ''}
 							album={item.album || ''}
+							artworkUrl={recentArtwork[item.id] || ''}
 							onClick={() => openTab(item)}
 						/>
 					{/each}
@@ -291,7 +279,7 @@
 						<p class="text-xs text-neutral-300 dark:text-neutral-600 mt-1">Try searching for tabs to build your taste profile</p>
 					</div>
 				{:else}
-					<div class="divide-y divide-neutral-100 dark:divide-neutral-800/50 max-h-[400px] overflow-y-auto">
+					<div class="divide-y divide-neutral-100 dark:divide-neutral-800/50 max-h-[50vh] overflow-y-auto">
 						{#each recommended as tab}
 							<ResultCard
 								id={tab.id}
@@ -330,7 +318,7 @@
 						<p class="text-sm text-neutral-400 dark:text-neutral-500">No tabs to discover yet</p>
 					</div>
 				{:else}
-					<div class="divide-y divide-neutral-100 dark:divide-neutral-800/50 max-h-[400px] overflow-y-auto">
+					<div class="divide-y divide-neutral-100 dark:divide-neutral-800/50 max-h-[50vh] overflow-y-auto">
 						{#each discover as tab}
 							<ResultCard
 								id={tab.id}

--- a/src/library/components/MiniPlayer.svelte
+++ b/src/library/components/MiniPlayer.svelte
@@ -5,6 +5,7 @@
 	import { tabStore } from '../utils/store';
 	import { openTabById } from '../utils/openTab';
 	import { displayTime } from '../utils/format';
+	import { fetchSingleArtwork } from '../utils/artwork';
 	import ProgressBar from './ProgressBar.svelte';
 	import ArtistTooltip from './ArtistTooltip.svelte';
 
@@ -68,31 +69,11 @@
 		const artist = state.artist || currentTab?.artist || '';
 		const title = state.title || currentTab?.title || '';
 		if (!artist || !title) return;
-		const SEARCH_API_BASE_URL = import.meta.env.VITE_SEARCH_API_BASE_URL;
-		if (!SEARCH_API_BASE_URL) return;
 		const generation = ++artworkFetchGeneration;
-		try {
-			// Try song artwork first
-			const resp = await fetch(`${SEARCH_API_BASE_URL}/api/metadata/artwork?artist=${encodeURIComponent(artist)}&title=${encodeURIComponent(title)}`);
-			if (generation !== artworkFetchGeneration) return;
-			if (resp.ok) {
-				const data = await resp.json();
-				if (generation !== artworkFetchGeneration) return;
-				if (data.artworkUrl) {
-					artworkUrl = data.artworkUrl;
-					return;
-				}
-			}
-			// Fallback: use artist image
-			if (!artist) return;
-			const artistResp = await fetch(`${SEARCH_API_BASE_URL}/api/metadata/artist/${encodeURIComponent(artist)}`);
-			if (generation !== artworkFetchGeneration) return;
-			if (artistResp.ok) {
-				const artistData = await artistResp.json();
-				if (generation !== artworkFetchGeneration) return;
-				artworkUrl = artistData.image || null;
-			}
-		} catch {}
+		const url = await fetchSingleArtwork(artist, title);
+		if (generation === artworkFetchGeneration) {
+			artworkUrl = url;
+		}
 	}
 
 	$: currentTime = state.duration > 0 ? displayTime(Math.round((state.progress / 100) * state.duration / 1000)) : '00:00';

--- a/src/library/components/ResultCard.svelte
+++ b/src/library/components/ResultCard.svelte
@@ -73,7 +73,7 @@
 </script>
 
 <button
-	class="group flex items-center gap-4 w-full px-3 py-3.5 sm:px-4 sm:py-4 text-left hover:bg-neutral-50 dark:hover:bg-neutral-800/60 active:bg-neutral-100 dark:active:bg-neutral-700/50 active:scale-[0.99] transition-all duration-150 cursor-pointer"
+	class="group flex items-center gap-4 w-full px-3 py-3.5 sm:px-4 sm:py-4 text-left hover:bg-neutral-50 dark:hover:bg-neutral-800/60 active:bg-neutral-100 dark:active:bg-neutral-700/50 active:scale-[0.99] transition-all transition-colors duration-150 cursor-pointer"
 	on:click={onClick}
 >
 	<!-- Icon -->
@@ -140,7 +140,7 @@
 				class="p-1.5 rounded-full active:scale-90 transition-all duration-150
 					{isFavorite
 						? 'text-red-500'
-						: 'text-neutral-300 dark:text-neutral-600 sm:opacity-0 sm:group-hover:opacity-100 hover:text-red-400'}"
+						: 'text-neutral-300 dark:text-neutral-600 opacity-60 hover:opacity-100 hover:text-red-400'}"
 				on:click={toggleFavorite}
 				aria-label="{isFavorite ? 'Remove' : 'Add'} {title} {isFavorite ? 'from' : 'to'} favorites"
 			>

--- a/src/library/components/SkeletonCard.svelte
+++ b/src/library/components/SkeletonCard.svelte
@@ -1,7 +1,7 @@
 <div class="flex items-center gap-3 w-full p-3">
-	<div class="flex-shrink-0 w-10 h-10 rounded bg-neutral-200 dark:bg-neutral-800 animate-pulse" />
+	<div class="flex-shrink-0 w-10 h-10 rounded bg-neutral-200 dark:bg-neutral-900 animate-pulse" />
 	<div class="flex-1 min-w-0 space-y-2">
-		<div class="h-4 w-3/4 bg-neutral-200 dark:bg-neutral-800 rounded animate-pulse" />
-		<div class="h-3 w-1/2 bg-neutral-100 dark:bg-neutral-800/60 rounded animate-pulse" />
+		<div class="h-4 w-3/4 bg-neutral-200 dark:bg-neutral-900 rounded animate-pulse" />
+		<div class="h-3 w-1/2 bg-neutral-100 dark:bg-neutral-900/60 rounded animate-pulse" />
 	</div>
 </div>

--- a/src/library/utils/artwork.ts
+++ b/src/library/utils/artwork.ts
@@ -1,49 +1,140 @@
+/**
+ * Shared artwork fetching utility.
+ * All pages should use this for consistent image retrieval with fallbacks.
+ */
 import { browser } from '$app/environment';
 
 const SEARCH_API_BASE_URL = import.meta.env.VITE_SEARCH_API_BASE_URL;
 
+// Module-level cache shared across all components during the session
+const artworkCache: Record<string, string> = {};
+
 /**
- * Fetch artwork URLs for a batch of items from the metadata API.
- * Merges into the existing map and returns the updated map.
+ * Fetch artwork for multiple items using the batch endpoint.
+ * Falls back to individual artist image requests for any items
+ * the batch couldn't resolve.
  */
 export async function fetchArtworkBatch(
-	items: { id: string; artist?: string; title: string }[],
-	existing: Record<string, string>,
-	limit: number = 10
+	items: Array<{ id: string; artist?: string; title?: string }>,
+	existing: Record<string, string> = {}
 ): Promise<Record<string, string>> {
 	if (!browser || !SEARCH_API_BASE_URL) return existing;
 
-	const updated = { ...existing };
-	for (const item of items.slice(0, limit)) {
-		if (updated[item.id]) continue;
-		try {
-			const resp = await fetch(
-				`${SEARCH_API_BASE_URL}/api/metadata/artwork?artist=${encodeURIComponent(item.artist || '')}&title=${encodeURIComponent(item.title)}`
-			);
-			if (resp.ok) {
-				const data = await resp.json();
-				if (data.artworkUrl) {
-					updated[item.id] = data.artworkUrl;
+	const result = { ...existing };
+
+	// Apply cached values first
+	const toFetch: typeof items = [];
+	for (const item of items) {
+		if (result[item.id]) continue;
+		if (artworkCache[item.id]) {
+			result[item.id] = artworkCache[item.id];
+		} else {
+			toFetch.push(item);
+		}
+	}
+	if (toFetch.length === 0) return result;
+
+	// Phase 1: Batch request (tries song artwork + artist image on backend)
+	try {
+		const resp = await fetch(`${SEARCH_API_BASE_URL}/api/metadata/artwork/batch`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(
+				toFetch.map((t) => ({
+					id: t.id,
+					artist: t.artist || '',
+					title: t.title || ''
+				}))
+			)
+		});
+		if (resp.ok) {
+			const data = await resp.json();
+			for (const [id, url] of Object.entries(data)) {
+				if (url) {
+					result[id] = url as string;
+					artworkCache[id] = url as string;
 				}
 			}
-		} catch {}
+		}
+	} catch {}
+
+	// Phase 2: For items still missing, try individual artist endpoint
+	// (uses the full smart lookup: TheAudioDB → MusicBrainz → compound split)
+	const stillMissing = toFetch.filter((t) => !result[t.id]);
+	if (stillMissing.length > 0) {
+		const uniqueArtists = new Map<string, string[]>();
+		for (const item of stillMissing) {
+			const artist = item.artist || '';
+			if (!artist) continue;
+			if (!uniqueArtists.has(artist)) uniqueArtists.set(artist, []);
+			uniqueArtists.get(artist)!.push(item.id);
+		}
+
+		await Promise.allSettled(
+			Array.from(uniqueArtists.entries()).map(async ([artist, ids]) => {
+				try {
+					const resp = await fetch(
+						`${SEARCH_API_BASE_URL}/api/metadata/artist/${encodeURIComponent(artist)}`
+					);
+					if (resp.ok) {
+						const data = await resp.json();
+						if (data.image) {
+							for (const id of ids) {
+								if (!result[id]) {
+									result[id] = data.image;
+									artworkCache[id] = data.image;
+								}
+							}
+						}
+					}
+				} catch {}
+			})
+		);
 	}
-	return updated;
+
+	return result;
 }
 
 /**
- * Fetch artwork for a single song (artist + title).
+ * Fetch artwork for a single item (used by MiniPlayer, TabViewer).
+ * Tries song artwork first, then artist image.
  */
-export async function fetchSingleArtwork(artist: string, title: string): Promise<string | null> {
-	if (!browser || !SEARCH_API_BASE_URL || !artist || !title) return null;
+export async function fetchSingleArtwork(
+	artist: string,
+	title: string
+): Promise<string | null> {
+	if (!browser || !SEARCH_API_BASE_URL || !artist) return null;
+
+	const cacheKey = `${artist}:${title}`;
+	if (artworkCache[cacheKey]) return artworkCache[cacheKey];
+
+	// Try song artwork
 	try {
 		const resp = await fetch(
 			`${SEARCH_API_BASE_URL}/api/metadata/artwork?artist=${encodeURIComponent(artist)}&title=${encodeURIComponent(title)}`
 		);
 		if (resp.ok) {
 			const data = await resp.json();
-			return data.artworkUrl || null;
+			if (data.artworkUrl) {
+				artworkCache[cacheKey] = data.artworkUrl;
+				return data.artworkUrl;
+			}
 		}
 	} catch {}
+
+	// Fallback: artist image
+	try {
+		const resp = await fetch(
+			`${SEARCH_API_BASE_URL}/api/metadata/artist/${encodeURIComponent(artist)}`
+		);
+		if (resp.ok) {
+			const data = await resp.json();
+			if (data.image) {
+				artworkCache[cacheKey] = data.image;
+				return data.image;
+			}
+		}
+	} catch {}
+
 	return null;
 }

--- a/src/library/utils/preferences.ts
+++ b/src/library/utils/preferences.ts
@@ -15,8 +15,29 @@ export interface UserPreferences {
 
 const STORAGE_KEY = 'user-preferences';
 
-export const DEFAULT_SOUNDFONT =
+export const SOUNDFONT_LIGHT =
 	'https://cdn.jsdelivr.net/npm/@coderline/alphatab@1.5.0/dist/soundfont/sonivox.sf2';
+
+export const SOUNDFONT_QUALITY =
+	'https://cdn.jsdelivr.net/gh/spessasus/SpessaSynth@24e5f18b6a6a5f1c56a56b7d9d589f52161cf490/soundfonts/GeneralUserGS.sf3';
+
+// Use quality soundfont by default, fall back to light on slow connections
+function getDefaultSoundFont(): string {
+	if (typeof navigator !== 'undefined' && 'connection' in navigator) {
+		const conn = (navigator as any).connection;
+		// Slow connection: effectiveType is 'slow-2g', '2g', or '3g'
+		if (conn?.effectiveType && ['slow-2g', '2g', '3g'].includes(conn.effectiveType)) {
+			return SOUNDFONT_LIGHT;
+		}
+		// Very low bandwidth (< 1 Mbps)
+		if (conn?.downlink && conn.downlink < 1) {
+			return SOUNDFONT_LIGHT;
+		}
+	}
+	return SOUNDFONT_QUALITY;
+}
+
+export const DEFAULT_SOUNDFONT = getDefaultSoundFont();
 
 export const SOUNDFONT_PRESETS = [
 	{
@@ -34,6 +55,30 @@ export const SOUNDFONT_PRESETS = [
 		size: '~10 MB',
 		tier: 'balanced' as const,
 		url: 'https://cdn.jsdelivr.net/gh/spessasus/SpessaSynth@24e5f18b6a6a5f1c56a56b7d9d589f52161cf490/soundfonts/GeneralUserGS.sf3'
+	},
+	{
+		id: 'yamaha-xg',
+		name: 'Yamaha XG Sound Set',
+		description: 'Compact Yamaha XG GM set, good for quick loading',
+		size: '~3.8 MB',
+		tier: 'light' as const,
+		url: 'https://cdn.jsdelivr.net/npm/@logue/sf2synth@0.8.0/dist/Yamaha%20XG%20Sound%20Set.sf2'
+	},
+	{
+		id: 'airfont320',
+		name: 'Airfont 320',
+		description: 'General MIDI light soundfont with rich instrument samples',
+		size: '~9.7 MB',
+		tier: 'balanced' as const,
+		url: 'https://cdn.jsdelivr.net/npm/@logue/sf2synth@0.8.0/dist/A320U.sf2'
+	},
+	{
+		id: 'fluidr3mono',
+		name: 'FluidR3 Mono GM',
+		description: 'Classic FluidR3 GM set, mono version, high quality',
+		size: '~14.6 MB',
+		tier: 'balanced' as const,
+		url: 'https://cdn.jsdelivr.net/gh/musescore/MuseScore@2.1/share/sound/FluidR3Mono_GM.sf3'
 	}
 ];
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,7 +20,7 @@
 
 	$: currentTab = $tabStore;
 	$: isOnPlay = $page.url.pathname.includes('/play');
-	$: showMiniPlayer = currentTab?.fileAsB64 && !isOnPlay;
+	$: showMiniPlayer = !!(currentTab?.fileAsB64) && !isOnPlay;
 
 	let miniPreviewVisible = get(preferencesStore).showMiniPlayerPreview;
 	let miniHovered = false;
@@ -228,6 +228,27 @@
 		try { api.render(); } catch {}
 	}
 
+	// Track the current soundfont URL to detect changes
+	let currentSoundFontUrl = get(preferencesStore).soundFontUrl;
+
+	// Subscribe to soundfont URL changes and apply at runtime
+	$: if (browser && $preferencesStore.soundFontUrl && $preferencesStore.soundFontUrl !== currentSoundFontUrl) {
+		const newUrl = $preferencesStore.soundFontUrl;
+		currentSoundFontUrl = newUrl;
+		const api = get(playerApi);
+		if (api) {
+			// Pause playback before changing soundfont
+			try { api.pause(); } catch {}
+			// Update the soundfont setting and reload
+			api.settings.player.soundFont = newUrl;
+			api.updateSettings();
+			// Reset soundfont loaded state so UI shows loading progress
+			updatePlayerState({ soundFontLoaded: false, soundFontProgress: 0 });
+			// loadSoundFont triggers re-download; soundFontLoaded event will fire when done
+			api.loadSoundFont(newUrl, false);
+		}
+	}
+
 	// Subscribe to theme changes to apply to alphaTab even when not on /play route
 	$: if (browser && $themeStore !== undefined) {
 		const api = get(playerApi);
@@ -407,7 +428,7 @@
 		{/if}
 	</div>
 
-	<main id="main-content" class="animate-fade-in min-h-screen {showMiniPlayer ? (miniPreviewVisible ? 'pb-[280px] sm:pb-14' : 'pb-14') : ''}">
+	<main id="main-content" class="animate-fade-in min-h-screen {showMiniPlayer ? (miniPreviewVisible ? 'pb-[272px] sm:pb-14' : 'pb-14') : ''}">
 		<slot />
 	</main>
 

--- a/src/routes/collection/+page.svelte
+++ b/src/routes/collection/+page.svelte
@@ -4,6 +4,7 @@
 	import { page } from '$app/stores';
 	import { browser } from '$app/environment';
 	import { onMount } from 'svelte';
+	import { fade } from 'svelte/transition';
 	import Header from '../../library/components/Header.svelte';
 	import ResultCard from '../../library/components/ResultCard.svelte';
 	import { favoritesStore } from '../../library/utils/favorites';
@@ -14,6 +15,7 @@
 	import { arrayBufferToBase64 } from '../../library/utils/utils';
 	import { toastStore } from '../../library/utils/toast';
 	import { openTabById } from '../../library/utils/openTab';
+	import { fetchArtworkBatch } from '../../library/utils/artwork';
 	import { preferencesStore, DEFAULT_SOUNDFONT, SOUNDFONT_PRESETS } from '../../library/utils/preferences';
 	import { favoriteArtistsStore } from '../../library/utils/favoriteArtists';
 	import { activeVideoId } from '../../library/utils/playerStore';
@@ -80,40 +82,19 @@
 		}
 	}
 
+	let favArtworkFetched = false;
+	let histArtworkFetched = false;
+
 	async function fetchFavArtwork() {
-		const SEARCH_API_BASE_URL = import.meta.env.VITE_SEARCH_API_BASE_URL;
-		if (!SEARCH_API_BASE_URL) return;
-		for (const item of favorites.slice(0, 12)) {
-			if (favArtwork[item.id]) continue;
-			try {
-				const resp = await fetch(`${SEARCH_API_BASE_URL}/api/metadata/artwork?artist=${encodeURIComponent(item.artist)}&title=${encodeURIComponent(item.title)}`);
-				if (resp.ok) {
-					const data = await resp.json();
-					if (data.artworkUrl) {
-						favArtwork[item.id] = data.artworkUrl;
-						favArtwork = favArtwork;
-					}
-				}
-			} catch {}
-		}
+		if (favArtworkFetched) return;
+		favArtworkFetched = true;
+		favArtwork = await fetchArtworkBatch(favorites.slice(0, 20), favArtwork);
 	}
 
 	async function fetchHistArtwork() {
-		const SEARCH_API_BASE_URL = import.meta.env.VITE_SEARCH_API_BASE_URL;
-		if (!SEARCH_API_BASE_URL) return;
-		for (const item of historyItems.slice(0, 10)) {
-			if (histArtwork[item.id]) continue;
-			try {
-				const resp = await fetch(`${SEARCH_API_BASE_URL}/api/metadata/artwork?artist=${encodeURIComponent(item.artist)}&title=${encodeURIComponent(item.title)}`);
-				if (resp.ok) {
-					const data = await resp.json();
-					if (data.artworkUrl) {
-						histArtwork[item.id] = data.artworkUrl;
-						histArtwork = histArtwork;
-					}
-				}
-			} catch {}
-		}
+		if (histArtworkFetched) return;
+		histArtworkFetched = true;
+		histArtwork = await fetchArtworkBatch(historyItems.slice(0, 20), histArtwork);
 	}
 
 	$: if (favorites.length > 0) fetchFavArtwork();
@@ -324,7 +305,7 @@
 		</div>
 	{:else if activeTab === 'favorites'}
 		<!-- ==================== FAVORITES TAB - SIDE BY SIDE ==================== -->
-		<div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+		<div class="grid grid-cols-1 lg:grid-cols-3 gap-4" transition:fade={{ duration: 150 }}>
 			<!-- LEFT COLUMN (2/3 width) -->
 			<div class="lg:col-span-2 space-y-6">
 				<!-- Favorite Artists (horizontal scroll) -->
@@ -491,7 +472,7 @@
 
 	{:else if activeTab === 'history'}
 		<!-- ==================== HISTORY TAB - GROUPED BY DAY ==================== -->
-		<div>
+		<div transition:fade={{ duration: 150 }}>
 			<div class="flex items-center justify-between mb-3">
 				<h2 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 flex items-center gap-2">
 					<i class="material-icons !text-lg text-neutral-400">history</i>
@@ -553,7 +534,7 @@
 
 	{:else if activeTab === 'settings'}
 		<!-- ==================== SETTINGS TAB ==================== -->
-		<div class="overflow-x-hidden">
+		<div class="overflow-x-hidden" transition:fade={{ duration: 150 }}>
 
 			<!-- ===== AUDIO SECTION ===== -->
 			<div class="flex items-center gap-2 mb-3 mt-0">

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -15,6 +15,7 @@
 	import { arrayBufferToBase64 } from '../../library/utils/utils';
 	import { favoriteArtistsStore } from '../../library/utils/favoriteArtists';
 	import { openTabById } from '../../library/utils/openTab';
+	import { fetchArtworkBatch } from '../../library/utils/artwork';
 
 	const SEARCH_API_BASE_URL = import.meta.env.VITE_SEARCH_API_BASE_URL;
 	const SEARCH_API_TIMEOUT = Number(import.meta.env.VITE_SEARCH_API_TIMEOUT) || 10000;
@@ -278,31 +279,7 @@
 	}
 
 	async function fetchArtworkForTabs(tabList: TabResult[]) {
-		if (!SEARCH_API_BASE_URL) return;
-		const toFetch = tabList.filter(t => !tabArtwork[t.id]);
-		if (toFetch.length === 0) return;
-
-		try {
-			const resp = await fetch(`${SEARCH_API_BASE_URL}/api/metadata/artwork/batch`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(toFetch.map(t => ({
-					id: t.id,
-					artist: t.artist || '',
-					title: t.title
-				})))
-			});
-			if (resp.ok) {
-				const data = await resp.json();
-				for (const [id, url] of Object.entries(data)) {
-					if (url) tabArtwork[id] = url as string;
-				}
-				tabArtwork = tabArtwork;
-			}
-		} catch {
-			// Fallback: try individual artist images for tabs without artwork
-			// (keeps some images showing even if batch endpoint is unavailable)
-		}
+		tabArtwork = await fetchArtworkBatch(tabList, tabArtwork);
 	}
 
 	async function performSearch(force: boolean = false): Promise<void> {
@@ -520,7 +497,7 @@
 <div class="max-w-4xl mx-auto px-4 min-h-[calc(100vh-3.5rem)]">
 	{#if loading && currentPage === 1 && !tabs.length}
 		<!-- Loading -->
-		<div class="flex flex-col items-center justify-center h-[calc(100vh-7rem)] gap-4">
+		<div class="flex flex-col items-center justify-center h-[calc(100vh-3.5rem)] gap-4">
 			<div class="animate-spin rounded-full h-10 w-10 border-2 border-neutral-300 border-t-violet-500" />
 			<p class="text-sm text-neutral-400 dark:text-neutral-500">
 				{#if searchingMore}
@@ -533,7 +510,7 @@
 
 	{:else if error}
 		<!-- Error -->
-		<div class="flex flex-col items-center justify-center h-[calc(100vh-7rem)]">
+		<div class="flex flex-col items-center justify-center h-[calc(100vh-3.5rem)]">
 			<i class="material-icons !text-5xl text-neutral-300 dark:text-neutral-600 mb-4">error_outline</i>
 			<p class="text-neutral-600 dark:text-neutral-400 mb-4">{error}</p>
 			<button
@@ -547,9 +524,9 @@
 	{:else if tabs.length > 0}
 		<!-- Artist hero cards (when search matches artists) -->
 		{#if artistHeroes.length > 0}
-			<div class="flex gap-3 overflow-x-auto py-3 px-1 scrollbar-thin scrollbar-thumb-neutral-300 dark:scrollbar-thumb-neutral-600">
+			<div class="flex gap-3 overflow-x-auto scroll-smooth snap-x snap-mandatory py-3 px-1 scrollbar-thin scrollbar-thumb-neutral-300 dark:scrollbar-thumb-neutral-600">
 				{#each artistHeroes as hero}
-					<div class="flex-shrink-0 w-[260px] sm:w-[300px] rounded-xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 overflow-hidden">
+					<div class="flex-shrink-0 snap-start w-[260px] sm:w-[300px] rounded-xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 overflow-hidden">
 						<!-- Top: image + name + follow -->
 						<button
 							class="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors"
@@ -652,20 +629,20 @@
 
 	{:else if query.length >= 2}
 		<!-- No results -->
-		<div class="flex flex-col items-center justify-center h-[calc(100vh-7rem)]">
+		<div class="flex flex-col items-center justify-center h-[calc(100vh-3.5rem)]">
 			<i class="material-icons !text-5xl text-neutral-300 dark:text-neutral-600 mb-4">search_off</i>
 			<p class="text-neutral-600 dark:text-neutral-400">No results for "{query}"</p>
 		</div>
 
 	{:else if query.length > 0 && query.length < 2}
 		<!-- Too short -->
-		<div class="flex flex-col items-center justify-center h-[calc(100vh-7rem)]">
+		<div class="flex flex-col items-center justify-center h-[calc(100vh-3.5rem)]">
 			<p class="text-neutral-500 dark:text-neutral-400 text-sm">Type at least 2 characters to search</p>
 		</div>
 
 	{:else}
 		<!-- Empty search - show prompt -->
-		<div class="flex flex-col items-center justify-center h-[calc(100vh-7rem)]">
+		<div class="flex flex-col items-center justify-center h-[calc(100vh-3.5rem)]">
 			<i class="material-icons !text-5xl text-neutral-300 dark:text-neutral-600 mb-4">search</i>
 			<p class="text-neutral-500 dark:text-neutral-400 text-sm">Search for tabs by song, artist, or album</p>
 		</div>


### PR DESCRIPTION
Artwork:
- Shared artwork.ts utility with batch endpoint + artist fallback
- All pages use fetchArtworkBatch/fetchSingleArtwork (HomeFeed, search, collection, MiniPlayer)
- Session-level cache prevents redundant requests across navigation
- Fix infinite reactive loop in artwork fetching

Layout & UX:
- Consistent full-height layout across all pages
- Responsive scroll containers (30vh/50vh instead of fixed px)
- Favorite button always visible on mobile
- Header shadow on scroll, collection tab fade transitions
- Artist hero carousel snap scrolling
- Fix skeleton card dark mode, mini-player padding

Soundfonts:
- Live soundfont switching (applies immediately without page reload)
- Default to GeneralUser GS (10MB), auto-fallback to Sonivox on slow connections
- 3 new presets: Yamaha XG, Airfont 320, FluidR3 Mono GM

Artist heroes:
- Enhanced cards with follow heart, tags, bio
- Compound artist name splitting for hero detection
- Up to 10 hero cards (was 3)