### PR TITLE
fix: prevent infinite loading when navigating from search to play

### DIFF
--- a/src/library/components/TabViewer.svelte
+++ b/src/library/components/TabViewer.svelte
@@ -8,7 +8,7 @@
 	import { themeStore } from '../utils/theme';
 	import { toastStore } from '../utils/toast';
 	import { favoritesStore } from '../utils/favorites';
-	import { playerApi, playerTarget, playerState, updatePlayerState, isFullPlayerView, audioSource, videoSyncOffset, isTransitioning } from '../utils/playerStore';
+	import { playerApi, playerTarget, playerState, updatePlayerState, isFullPlayerView, audioSource, videoSyncOffset, isTransitioning, loadedTabB64 } from '../utils/playerStore';
 	import { browser } from '$app/environment';
 	import { preferencesStore } from '../utils/preferences';
 	import SettingSlider from '$components/SettingSlider.svelte';
@@ -1763,6 +1763,18 @@
 
 			// Add detailed event listeners for the full player view
 			setupFullPlayerListeners(api);
+
+			// Safety net: if the tab in the store wasn't loaded into alphaTab
+			// (e.g., due to race between reactive block, navigation, and reparenting),
+			// trigger the load now that the DOM is in its final position.
+			if (data.fileAsB64 && get(playerState).soundFontLoaded) {
+				const loaded = get(loadedTabB64);
+				if (data.fileAsB64 !== loaded) {
+					updatePlayerState({ scoreLoaded: false, isRendering: true });
+					api.load(base64ToArrayBuffer(data.fileAsB64));
+					loadedTabB64.set(data.fileAsB64);
+				}
+			}
 		}
 
 		// --- Theme subscription ---

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -266,7 +266,8 @@
 				// API not yet created - ensure init (soundFont load will trigger tab load)
 				ensureApiInitialized();
 			} else if (get(playerState).soundFontLoaded) {
-				// API ready, load immediately
+				// Reset score state so UI shows loading during transition
+				updatePlayerState({ scoreLoaded: false, isRendering: true });
 				api.load(base64ToArrayBuffer(currentTab.fileAsB64));
 				loadedTabB64.set(currentTab.fileAsB64);
 			}


### PR DESCRIPTION
## Summary
- Reset `playerState.scoreLoaded` to `false` when the layout loads a new tab into alphaTab, so the UI shows a proper loading spinner during tab transitions instead of displaying stale state
- Add safety net in TabViewer's `onMount` to verify the tab was loaded into alphaTab after DOM reparenting — if the layout's reactive block missed the load due to a race with navigation, TabViewer triggers it

## Context
When clicking a search result to navigate from `/search` to `/play`, the play page could get stuck in an infinite loading state. The root cause was that `scoreLoaded` was never reset when loading a new tab, so the UI could show stale state from the previous tab. Combined with timing-sensitive interactions between the Svelte reactive block, SvelteKit navigation, and DOM reparenting of the persistent alphaTab element, the `scoreLoaded` event could be missed.

## Test plan
- [ ] Navigate to `/search?q=<song>&tab=<existing-tab-id>`, click a different result → play page loads correctly
- [ ] Click Songsterr variant on a result card → play page loads correctly  
- [ ] Mini player preview works when navigating away from `/play`
- [ ] Clicking mini player to return to `/play` shows the tab correctly