### PR TITLE
refactor: use bar indices as single source of truth for loop state

### DIFF
--- a/src/library/components/TabViewer.svelte
+++ b/src/library/components/TabViewer.svelte
@@ -297,6 +297,10 @@
 			const ytPlayer = $videoPlayerRef;
 			if (!ytPlayer || !api || !duration) return;
 
+			// Don't override playback position when a loop is active —
+			// the loop owns the playback range and position.
+			if (loopStartBar !== null && loopEndBar !== null && loopEnabled) return;
+
 			try {
 				const videoTime = ytPlayer.getCurrentTime?.() || 0;
 				const videoDuration = ytPlayer.getDuration?.() || 0;
@@ -1823,6 +1827,25 @@
 						}
 						return bars;
 					} catch { return []; }
+				},
+				setMockVideo: (currentTimeSec: number, durationSec: number) => {
+					const mockPlayer = {
+						getCurrentTime: () => currentTimeSec,
+						getDuration: () => durationSec,
+						getPlayerState: () => 1,
+						pauseVideo: () => {},
+						playVideo: () => {},
+						seekTo: () => {},
+						mute: () => {},
+						unMute: () => {},
+						setVolume: () => {},
+					};
+					activeVideoId.set('mock-video-id');
+					videoPlayerRef.set(mockPlayer);
+				},
+				clearMockVideo: () => {
+					activeVideoId.set(null);
+					videoPlayerRef.set(null);
 				},
 			};
 		}

--- a/tests/loop.spec.ts
+++ b/tests/loop.spec.ts
@@ -386,4 +386,49 @@ test.describe('Loop Interactions', () => {
 
 		await page.keyboard.press('Space');
 	});
+
+	// --- Test 22: Loop works when YouTube mini player is active ---
+	// Regression: video sync interval overrides api.player.timePosition every 200ms,
+	// ignoring the loop range and pushing playback past the loop end.
+	test('loop stays within bounds when video is active', async ({ page }) => {
+		await setupPlayPage(page);
+
+		// Create a loop in the 30-50% range
+		await dragProgressBar(page, 30, 50);
+		const bounds = await getTestApi<any>(page, 'getLoopBounds');
+		expect(bounds).not.toBeNull();
+
+		const loopMs = await getTestApi<any>(page, 'getLoopMs');
+		const duration = await getTestApi<number>(page, 'getDuration');
+		const loopStartPct = (loopMs.start / duration) * 100;
+		const loopEndPct = (loopMs.end / duration) * 100;
+
+		// Seek to loop start and begin playback BEFORE activating video
+		await seekToPercent(page, loopStartPct + 1);
+		await waitForSeekSettled(page, loopStartPct + 1, 5);
+		await page.keyboard.press('Space');
+		await waitForPlaying(page, true);
+
+		// NOW activate a mock video that reports time PAST the loop end (80% of song).
+		// The video sync interval will try to push playback to 80%, which is outside the loop.
+		const videoTimeSec = (duration / 1000) * 0.8;
+		const videoDurationSec = duration / 1000;
+		await page.evaluate(
+			({ t, d }) => (window as any).__testApi.setMockVideo(t, d),
+			{ t: videoTimeSec, d: videoDurationSec }
+		);
+
+		// Wait for video sync to fire a few times (200ms interval)
+		await page.waitForTimeout(600);
+
+		// Sample progress — should stay within loop bounds despite video sync
+		const samples = await sampleProgress(page, 15, 200);
+		for (const s of samples) {
+			expect(s).toBeGreaterThan(loopStartPct - 5);
+			expect(s).toBeLessThan(loopEndPct + 5);
+		}
+
+		await page.keyboard.press('Space');
+		await page.evaluate(() => (window as any).__testApi.clearMockVideo());
+	});
 });


### PR DESCRIPTION
## Summary

Replace the loop's ms/tick state (`loopStart`, `loopEnd`, `loopStartTick`, `loopEndTick`) with bar indices (`loopStartBar`, `loopEndBar`) as the single source of truth. This eliminates lossy conversions between ms, score-level ticks, and expanded ticks that caused desync between the score overlay, playback range, and progress bar on songs with repeats.

### What changed
- **New helpers**: `barToExpandedRange()`, `barToMs()`, `barEndToMs()`, `msToBar()` — all backed by alphaTab's `MidiTickLookup` for repeat-aware conversion
- **All loop creation paths snap to bar boundaries**: score drag, progress bar drag, A/B keyboard shortcuts
- **Removed**: `msToTick`, `tickToMs`, `msToBarIdx`, `snapToBarBoundary`, `beatBarStartTick`, `beatBarEndTick` and other dead conversion code
- **Net reduction**: ~135 lines removed

### User-facing changes
- Loop endpoints snap to bar boundaries (no sub-bar precision)
- Overlay, playback, and progress bar are always perfectly in sync
- Works correctly on songs with repeats (e.g. "Le toit du monde")

## Test plan
- [x] All 14 loop Playwright tests pass
- [ ] Score drag loop on song with repeats → overlay and playback match
- [ ] Progress bar drag → snaps to bars, stays synced
- [ ] Move/resize loop on progress bar → stays synced
- [ ] A/B keyboard loop → snaps to bars
- [ ] Song without repeats → works as before