### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+build
+.svelte-kit
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@10.17.0 --activate
+
+# Install dependencies first (cached layer)
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["pnpm", "run", "start", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- Add `Dockerfile` and `.dockerignore` for containerized development

Part of workspace dockerization effort (tablatures/tablatures-workspace#1).

## Test plan
- [x] `docker build` succeeds
- [x] Frontend starts and serves on port 5173