### PR TITLE
fix: send full query to autocomplete API

### DIFF
--- a/src/library/components/SearchBar.svelte
+++ b/src/library/components/SearchBar.svelte
@@ -54,12 +54,6 @@
 		}
 	}
 
-	$: queryLastWord = (() => {
-		const trimmed = value.trimEnd();
-		const parts = trimmed.split(/\s+/);
-		return parts[parts.length - 1] || '';
-	})();
-
 	function suggestionIcon(type?: string): string {
 		if (type === 'artist') return 'person';
 		if (type === 'song') return 'music_note';


### PR DESCRIPTION
## Summary
- Send the complete search input to autocomplete API instead of only the last word
- Enables multi-word suggestions like "A Tout Le Monde"
- Simplify suggestion application to always replace full input value

Companion to tablatures/tablatures-api#3

## Test plan
- [x] Typing "A tout le monde" shows full song title suggestions with artist names
- [x] Clicking a suggestion fills search bar and triggers search
- [x] Single-word queries still work as before