### PR TITLE
fix: auto-follow cursor not working in fullscreen mode

### DIFF
--- a/src/library/components/TabViewer.svelte
+++ b/src/library/components/TabViewer.svelte
@@ -2539,6 +2539,10 @@
 
 	function handleFullscreenChange() {
 		isFullscreen = !!document.fullscreenElement;
+		// Rebind scroll listener to the correct target (window vs page element)
+		mountScrollTarget?.removeEventListener('scroll', handleUserScroll);
+		mountScrollTarget = isFullscreen && page ? page : window;
+		mountScrollTarget.addEventListener('scroll', handleUserScroll, { passive: true });
 	}
 
 	// --- Simplified auto-hide logic (Task 4) ---


### PR DESCRIPTION
## Summary
- The scroll listener for auto-follow was bound to `window` on mount
- In fullscreen, the scroll container changes to the `page` element, but the listener stayed on `window`
- User scrolling in fullscreen was invisible to the auto-follow logic, so the cursor was never followed
- Fix: rebind the scroll listener in `handleFullscreenChange()` to the correct target

## Test plan
- [x] Play a tab, enter fullscreen — cursor should auto-scroll as the tab plays
- [x] Scroll away manually in fullscreen — auto-follow should pause
- [x] Scroll back to cursor in fullscreen — auto-follow should resume
- [x] Exit fullscreen — auto-follow should continue working normally