### PR TITLE
feat: group duplicate tab versions and strip (N) suffixes

### DIFF
--- a/src/library/components/ResultCard.svelte
+++ b/src/library/components/ResultCard.svelte
@@ -69,6 +69,24 @@
 		return src || 'Unknown';
 	}
 
+	interface GroupedVariant {
+		source: string;
+		items: Array<{id: string; source: string; sourceUrl: string; trackCount?: number; instruments?: string[]}>;
+	}
+
+	$: groupedVariants = (() => {
+		if (!variants || variants.length <= 1) return [];
+		const groups = new Map<string, GroupedVariant>();
+		for (const v of variants) {
+			const label = getSourceLabel(v.source);
+			if (!groups.has(label)) {
+				groups.set(label, { source: v.source, items: [] });
+			}
+			groups.get(label)!.items.push(v);
+		}
+		return Array.from(groups.values());
+	})();
+
 	$: dotColor = sourceDotColor(source);
 </script>
 
@@ -112,22 +130,33 @@
 				<span class="text-[11px] text-neutral-400 dark:text-neutral-500">{trackCount} tracks</span>
 			{/if}
 		</div>
-		{#if variants && variants.length > 1}
+		{#if groupedVariants.length > 0}
 			<div class="flex gap-1.5 mt-1.5 flex-wrap">
-				{#each variants as variant}
-					<button
-						class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium border transition-colors
-							{variant.source === source
+				{#each groupedVariants as group}
+					{#if group.items.length === 1}
+						<button
+							class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium border transition-colors
+								{group.items[0].source === source
+									? 'bg-violet-100 dark:bg-violet-900/30 border-violet-300 dark:border-violet-700 text-violet-700 dark:text-violet-300'
+									: 'bg-neutral-100 dark:bg-neutral-800 border-neutral-200 dark:border-neutral-700 text-neutral-500 dark:text-neutral-400 hover:border-violet-300'}"
+							on:click|stopPropagation={() => onVariantClick?.(group.items[0])}
+						>
+							<span class="w-1.5 h-1.5 rounded-full {getSourceColor(group.source)}"></span>
+							{getSourceLabel(group.source)}
+							{#if group.items[0].trackCount}
+								<span class="text-neutral-400">({group.items[0].trackCount})</span>
+							{/if}
+						</button>
+					{:else}
+						<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium border
+							{group.items[0].source === source
 								? 'bg-violet-100 dark:bg-violet-900/30 border-violet-300 dark:border-violet-700 text-violet-700 dark:text-violet-300'
-								: 'bg-neutral-100 dark:bg-neutral-800 border-neutral-200 dark:border-neutral-700 text-neutral-500 dark:text-neutral-400 hover:border-violet-300'}"
-						on:click|stopPropagation={() => onVariantClick?.(variant)}
-					>
-						<span class="w-1.5 h-1.5 rounded-full {getSourceColor(variant.source)}"></span>
-						{getSourceLabel(variant.source)}
-						{#if variant.trackCount}
-							<span class="text-neutral-400">({variant.trackCount})</span>
-						{/if}
-					</button>
+								: 'bg-neutral-100 dark:bg-neutral-800 border-neutral-200 dark:border-neutral-700 text-neutral-500 dark:text-neutral-400'}">
+							<span class="w-1.5 h-1.5 rounded-full {getSourceColor(group.source)}"></span>
+							{getSourceLabel(group.source)}
+							<span class="text-neutral-400">({group.items.length})</span>
+						</span>
+					{/if}
 				{/each}
 			</div>
 		{/if}

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -133,13 +133,17 @@
 		};
 	}
 
+	function stripTrailingSuffix(title: string): string {
+		return title.replace(/\s*\(\d+\)\s*$/, '').trim();
+	}
+
 	function mergeResults(existing: TabResult[], incoming: TabResult[]): TabResult[] {
 		const byKey = new Map<string, TabResult>();
 		const byId = new Map<string, TabResult>();
 
 		function normalizeKey(tab: TabResult): string {
 			const a = normalizeArtist(tab.artist || 'unknown');
-			const t = (tab.title || '').toLowerCase().trim().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+			const t = stripTrailingSuffix(tab.title || '').toLowerCase().trim().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
 			return `${a}|${t}`;
 		}
 
@@ -158,8 +162,10 @@
 					}
 				}
 				existing.variants = existingVariants;
+				// Use the clean title (without suffix) for display
+				existing.title = stripTrailingSuffix(existing.title);
 			} else {
-				byKey.set(key, { ...tab });
+				byKey.set(key, { ...tab, title: stripTrailingSuffix(tab.title) });
 				if (tab.id) byId.set(tab.id, byKey.get(key)!);
 			}
 		}
@@ -304,8 +310,8 @@
 				try {
 					const localResults = await performLocalSearch();
 					if (localResults.length > 0) {
-						tabs = localResults;
-						totalResults = localResults.length;
+						tabs = mergeResults([], localResults);
+						totalResults = tabs.length;
 						loading = false;
 					}
 				} catch {


### PR DESCRIPTION
## Summary
- 15% of GP Tabs entries have `(N)` suffixes (e.g. "Battery (2)") — alternate transcriptions cluttering search results
- Strips trailing `(N)` from titles when grouping, so all versions merge into a single result row
- Local results now go through `mergeResults` for consistent grouping before live results arrive
- ResultCard shows grouped same-source variants as "GP Tabs (7)" instead of seven identical chips
- Cross-source variants (GP Tabs, Songsterr) still show individually for easy switching

Before: "Battery", "Battery (2)", "Battery (5)", "Battery (8)", "Battery (9)" as 5 separate results
After: "Battery" with a "GP Tabs (7)" chip

## Test plan
- [ ] Search "metallica battery" — should show one "Battery" result with "GP Tabs (7)" chip
- [ ] Search "sound of silence" — should show one S&G result with "GP Tabs (2)" and "Songsterr" chips
- [ ] Click variant chips — should load that specific version
- [ ] Titles should never display `(2)`, `(3)` etc suffixes