### PR TITLE
chore: upgrade alphaTab from v1.5.0 to v1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,6 @@ The Tablatures frontend uses environment variables to configure API endpoints, d
 
 - **SvelteKit** + TypeScript
 - **Tailwind CSS** for styling
-- **alphaTab 1.5.0** for tablature rendering and playback
+- **alphaTab 1.8.1** for tablature rendering and playback
 - **YouTube iFrame API** for video sync
 - **Vite** for building

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -67,10 +67,11 @@ declare global {
 			settings: { display: { resources: DisplayResources } };
 			score: Score;
 			load(data: ArrayBuffer): void;
+			play(): void;
 			pause(): void;
 			updateSettings(): void;
 			render(): void;
-			_beatCursor?: { element?: HTMLElement };
+			tickCache?: { masterBars: any[] } | null;
 		}
 
 		interface Gp7Exporter {

--- a/src/app.html
+++ b/src/app.html
@@ -5,7 +5,7 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		%sveltekit.head%
-		<script src="https://cdn.jsdelivr.net/npm/@coderline/alphatab@1.5.0/dist/alphaTab.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/@coderline/alphatab@1.8.1/dist/alphaTab.js"></script>
 		<script src="https://www.youtube.com/iframe_api"></script>
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/library/components/TabViewer.svelte
+++ b/src/library/components/TabViewer.svelte
@@ -199,9 +199,8 @@
 		autoFollow = true;
 		autoFollowDisengagedAt = 0;
 		// Scroll to current cursor position
-		const cursor = api?._beatCursor;
-		if (!cursor?.element) return;
-		const el = cursor.element;
+		const el = get(beatCursorEl);
+		if (!el) return;
 		const containerRect = target?.getBoundingClientRect();
 		const elRect = el.getBoundingClientRect();
 		if (!target || !containerRect) return;

--- a/src/library/components/TabViewer.svelte
+++ b/src/library/components/TabViewer.svelte
@@ -8,7 +8,7 @@
 	import { themeStore } from '../utils/theme';
 	import { toastStore } from '../utils/toast';
 	import { favoritesStore } from '../utils/favorites';
-	import { playerApi, playerTarget, playerState, updatePlayerState, isFullPlayerView, audioSource, videoSyncOffset, isTransitioning, setMasterVolumeDebounced } from '../utils/playerStore';
+	import { playerApi, playerTarget, playerState, updatePlayerState, isFullPlayerView, audioSource, videoSyncOffset, isTransitioning, setMasterVolumeDebounced, beatCursorEl } from '../utils/playerStore';
 	import { browser } from '$app/environment';
 	import { preferencesStore } from '../utils/preferences';
 	import SettingSlider from '$components/SettingSlider.svelte';
@@ -1422,7 +1422,7 @@
 	}
 
 	function checkCursorVisibility() {
-		const el = target?.querySelector('.at-cursor-beat') as HTMLElement | null;
+		const el = get(beatCursorEl);
 		if (!el) return;
 		const elRect = el.getBoundingClientRect();
 		const viewportHeight = isFullscreen && page ? page.clientHeight : window.innerHeight;
@@ -1608,7 +1608,7 @@
 		// Auto-scroll cursor
 		const onPositionScroll = (e: any) => {
 			if (!autoFollow || userScrolling) return;
-			const el = target?.querySelector('.at-cursor-beat') as HTMLElement | null;
+			const el = get(beatCursorEl);
 			if (!el) return;
 			const containerRect = target?.getBoundingClientRect();
 			const elRect = el.getBoundingClientRect();

--- a/src/library/components/TabViewer.svelte
+++ b/src/library/components/TabViewer.svelte
@@ -493,7 +493,7 @@
 	}
 
 	// --- Bar-based loop helpers (single source of truth) ---
-	// All use MidiTickLookup (api._tickCache) for repeat-aware conversion.
+	// All use MidiTickLookup (api.tickCache) for repeat-aware conversion.
 	// Minimal contiguous range strategy: for repeated bars, find the smallest
 	// span across all occurrences so loops stay within a single repeat pass.
 
@@ -504,7 +504,7 @@
 	function barToExpandedRange(startBar: number, endBar: number): { startTick: number; endTick: number } | null {
 		if (!api) return null;
 		try {
-			const entries = api._tickCache?.masterBars;
+			const entries = api.tickCache?.masterBars;
 			if (!entries || entries.length === 0) return null;
 			// Find all occurrences of endBar in the expanded sequence
 			const endOccurrences: number[] = [];
@@ -549,7 +549,7 @@
 		const range = barToExpandedRange(loopStartBar, loopEndBar);
 		if (!range) return null;
 		try {
-			const entries = api._tickCache?.masterBars;
+			const entries = api.tickCache?.masterBars;
 			if (!entries?.length) return null;
 			const total = entries[entries.length - 1].end;
 			if (total <= 0) return null;
@@ -564,7 +564,7 @@
 	function barToMs(barIdx: number): number {
 		if (!api || !duration || duration <= 0) return -1;
 		try {
-			const entries = api._tickCache?.masterBars;
+			const entries = api.tickCache?.masterBars;
 			if (!entries || entries.length === 0) return -1;
 			const totalExpanded = entries[entries.length - 1].end;
 			if (totalExpanded <= 0) return -1;
@@ -586,7 +586,7 @@
 	function barEndToMs(barIdx: number): number {
 		if (!api || !duration || duration <= 0) return -1;
 		try {
-			const entries = api._tickCache?.masterBars;
+			const entries = api.tickCache?.masterBars;
 			if (!entries || entries.length === 0) return -1;
 			const totalExpanded = entries[entries.length - 1].end;
 			if (totalExpanded <= 0) return -1;
@@ -608,7 +608,7 @@
 	function msToBar(ms: number): number {
 		if (!api || !duration || duration <= 0) return 0;
 		try {
-			const entries = api._tickCache?.masterBars;
+			const entries = api.tickCache?.masterBars;
 			if (!entries || entries.length === 0) return 0;
 			const totalExpanded = entries[entries.length - 1].end;
 			const expandedTick = (ms / duration) * totalExpanded;
@@ -1422,10 +1422,8 @@
 	}
 
 	function checkCursorVisibility() {
-		const cursor = api?._beatCursor;
-		if (!cursor || !cursor.element) return;
-
-		const el = cursor.element;
+		const el = target?.querySelector('.at-cursor-beat') as HTMLElement | null;
+		if (!el) return;
 		const elRect = el.getBoundingClientRect();
 		const viewportHeight = isFullscreen && page ? page.clientHeight : window.innerHeight;
 
@@ -1610,9 +1608,8 @@
 		// Auto-scroll cursor
 		const onPositionScroll = (e: any) => {
 			if (!autoFollow || userScrolling) return;
-			const cursor = apiRef?._beatCursor;
-			if (!cursor?.element) return;
-			const el = cursor.element;
+			const el = target?.querySelector('.at-cursor-beat') as HTMLElement | null;
+			if (!el) return;
 			const containerRect = target?.getBoundingClientRect();
 			const elRect = el.getBoundingClientRect();
 			if (!target || !containerRect) return;
@@ -1929,7 +1926,7 @@
 				},
 				getExpandedSequence: () => {
 					try {
-						const entries = api?._tickCache?.masterBars;
+						const entries = api?.tickCache?.masterBars;
 						if (!entries) return null;
 						return entries.map((e: any) => e.masterBar.index);
 					} catch { return null; }

--- a/src/library/utils/playerStore.ts
+++ b/src/library/utils/playerStore.ts
@@ -38,7 +38,7 @@ export const playerApi = writable<any>(null);
 // The persistent DOM element where alphaTab renders
 export const playerTarget = writable<HTMLElement | null>(null);
 
-// Cached beat cursor element (set once via customCursorHandler, avoids per-frame DOM queries)
+// Cached beat cursor element (set via querySelector after render, avoids per-frame DOM queries)
 export const beatCursorEl = writable<HTMLElement | null>(null);
 
 // Reactive player state for UI binding

--- a/src/library/utils/playerStore.ts
+++ b/src/library/utils/playerStore.ts
@@ -38,6 +38,9 @@ export const playerApi = writable<any>(null);
 // The persistent DOM element where alphaTab renders
 export const playerTarget = writable<HTMLElement | null>(null);
 
+// Cached beat cursor element (set once via customCursorHandler, avoids per-frame DOM queries)
+export const beatCursorEl = writable<HTMLElement | null>(null);
+
 // Reactive player state for UI binding
 export const playerState = writable<PlayerState>({ ...DEFAULT_STATE });
 

--- a/src/library/utils/preferences.ts
+++ b/src/library/utils/preferences.ts
@@ -16,7 +16,7 @@ export interface UserPreferences {
 const STORAGE_KEY = 'user-preferences';
 
 export const SOUNDFONT_LIGHT =
-	'https://cdn.jsdelivr.net/npm/@coderline/alphatab@1.5.0/dist/soundfont/sonivox.sf2';
+	'https://cdn.jsdelivr.net/npm/@coderline/alphatab@1.8.1/dist/soundfont/sonivox.sf2';
 
 export const SOUNDFONT_QUALITY =
 	'https://cdn.jsdelivr.net/gh/spessasus/SpessaSynth@24e5f18b6a6a5f1c56a56b7d9d589f52161cf490/soundfonts/GeneralUserGS.sf3';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -103,7 +103,7 @@
 			},
 			player: {
 				scrollMode: 0,
-				enablePlayer: true,
+				playerMode: 2, // EnabledSynthesizer — enablePlayer is broken in v1.8.x
 				enableUserInteraction: true,
 				enableCursor: true,
 				soundFont: prefs.soundFontUrl
@@ -123,9 +123,8 @@
 
 			// In mini player mode, always scroll to follow the cursor (skip during transitions)
 			if (!get(isTransitioning) && !get(isFullPlayerView) && playerHostAnchor && playerHostAnchor.classList.contains('player-host-mini')) {
-				const cursor = api?._beatCursor;
-				if (cursor?.element) {
-					const el = cursor.element;
+				const el = playerHostEl?.querySelector('.at-cursor-beat') as HTMLElement | null;
+				if (el) {
 					const anchorRect = playerHostAnchor.getBoundingClientRect();
 					const elRect = el.getBoundingClientRect();
 					if (anchorRect.width > 0 && elRect.width > 0) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
 	import { toastStore } from '../library/utils/toast';
 	import { tabStore } from '../library/utils/store';
 	import { validateFile, fileToBase64 } from '../library/utils/upload';
-	import { playerApi, playerTarget, playerState, updatePlayerState, isFullPlayerView, loadedTabB64, resetPlayerState, activeVideoId, isTransitioning, videoPlayerRef, audioSource } from '../library/utils/playerStore';
+	import { playerApi, playerTarget, playerState, updatePlayerState, isFullPlayerView, loadedTabB64, resetPlayerState, activeVideoId, isTransitioning, videoPlayerRef, audioSource, beatCursorEl } from '../library/utils/playerStore';
 	import { preferencesStore } from '../library/utils/preferences';
 	import { themeStore } from '../library/utils/theme';
 	import { base64ToArrayBuffer } from '../library/utils/utils';
@@ -123,7 +123,7 @@
 
 			// In mini player mode, always scroll to follow the cursor (skip during transitions)
 			if (!get(isTransitioning) && !get(isFullPlayerView) && playerHostAnchor && playerHostAnchor.classList.contains('player-host-mini')) {
-				const el = playerHostEl?.querySelector('.at-cursor-beat') as HTMLElement | null;
+				const el = get(beatCursorEl);
 				if (el) {
 					const anchorRect = playerHostAnchor.getBoundingClientRect();
 					const elRect = el.getBoundingClientRect();
@@ -191,6 +191,10 @@
 
 		api.renderFinished?.on(() => {
 			updatePlayerState({ isRendering: false });
+			// Cache beat cursor element once after render (avoids per-frame DOM queries during playback)
+			if (!get(beatCursorEl)) {
+				beatCursorEl.set(playerHostEl?.querySelector('.at-cursor-beat') as HTMLElement | null);
+			}
 		});
 
 		api.error?.on((error) => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -191,10 +191,8 @@
 
 		api.renderFinished?.on(() => {
 			updatePlayerState({ isRendering: false });
-			// Cache beat cursor element once after render (avoids per-frame DOM queries during playback)
-			if (!get(beatCursorEl)) {
-				beatCursorEl.set(playerHostEl?.querySelector('.at-cursor-beat') as HTMLElement | null);
-			}
+			// Re-query cursor element on every render (still avoids per-frame DOM queries)
+			beatCursorEl.set(playerHostEl?.querySelector('.at-cursor-beat') as HTMLElement | null);
 		});
 
 		api.error?.on((error) => {


### PR DESCRIPTION
fixes #122

## Summary

- Upgrades alphaTab CDN from v1.5.0 to v1.8.1 (6 releases spanning new features, bug fixes, and breaking changes)
- Replaces `enablePlayer: true` with `playerMode: EnabledSynthesizer` — the `enablePlayer` backward compat is broken in v1.8.x (`EnabledAutomatic` mode doesn't create a player)
- Migrates private API access (`_tickCache`, `_beatCursor`) to public alternatives (`tickCache`, DOM query `.at-cursor-beat`)

## Breaking changes addressed

| Change | Version | Fix |
|--------|---------|-----|
| Private member name mangling | v1.7.1 | `_tickCache` → `tickCache` (public since v1.2.3) |
| Private member name mangling | v1.7.1 | `_beatCursor` → DOM query `.at-cursor-beat` |
| `enablePlayer` broken | v1.8.x | Use `playerMode: 2` (EnabledSynthesizer) |

## Test plan

- [x] `svelte-check` passes with 0 errors
- [x] E2E tests: 53/55 pass (1 known-fragile score-drag test, 1 skipped YouTube mock)
- [x] Manual QA: play/pause, speed, volume, mute/unmute all tracks, solo, track switching, theme toggle, loop A/B, seek, arrow navigation
- [x] No console errors after full workflow