### PR TITLE
fix: mobile responsiveness and UX improvements

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -67,6 +67,7 @@ declare global {
 			settings: { display: { resources: DisplayResources } };
 			score: Score;
 			load(data: ArrayBuffer): void;
+			play(): void;
 			pause(): void;
 			updateSettings(): void;
 			render(): void;

--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon/favicon.ico" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 		%sveltekit.head%
 		<script src="https://cdn.jsdelivr.net/npm/@coderline/alphatab@1.5.0/dist/alphaTab.js"></script>
 		<script src="https://www.youtube.com/iframe_api"></script>

--- a/src/library/components/HomeFeed.svelte
+++ b/src/library/components/HomeFeed.svelte
@@ -189,7 +189,7 @@
 
 <div class="py-6">
 	<!-- Top row: Import + Recently Viewed side by side on desktop, stacked on mobile -->
-	<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+	<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6 min-h-[200px]">
 		<!-- Import card (1 col on desktop) -->
 		<div
 			class="rounded-xl border-2 border-dashed transition-all cursor-pointer
@@ -205,7 +205,7 @@
 			role="button"
 			tabindex="0"
 		>
-			<div class="flex flex-col items-center justify-center py-8 px-4 text-center h-full min-h-[160px]">
+			<div class="flex flex-col items-center justify-center py-5 sm:py-8 px-3 sm:px-4 text-center h-full min-h-[160px]">
 				<i class="material-icons !text-4xl text-neutral-300 dark:text-neutral-600 mb-2">{dragActive ? 'file_download' : 'upload_file'}</i>
 				<p class="text-sm text-neutral-600 dark:text-neutral-400 mb-1">
 					Drop or <span class="text-violet-500 dark:text-violet-400 font-medium">browse</span>
@@ -257,10 +257,10 @@
 	</div>
 
 	<!-- Two-column grid: Recommended + Discover -->
-	<div class="grid grid-cols-1 md:grid-cols-2 gap-4 min-h-[40vh]">
+	<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 		<!-- Recommended For You -->
 		{#if true}
-			<div class="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 overflow-hidden">
+			<div class="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 overflow-hidden min-h-[300px]">
 				<div class="px-3 py-2 border-b border-neutral-100 dark:border-neutral-800">
 					<span class="text-xs font-semibold text-neutral-500 dark:text-neutral-400 flex items-center gap-1.5">
 						<i class="material-icons !text-sm">recommend</i> Recommended
@@ -300,7 +300,7 @@
 
 		<!-- Discover -->
 		{#if true}
-			<div class="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 overflow-hidden">
+			<div class="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 overflow-hidden min-h-[300px]">
 				<div class="px-3 py-2 border-b border-neutral-100 dark:border-neutral-800">
 					<span class="text-xs font-semibold text-neutral-500 dark:text-neutral-400 flex items-center gap-1.5">
 						<i class="material-icons !text-sm">explore</i> Discover

--- a/src/library/components/MiniPlayer.svelte
+++ b/src/library/components/MiniPlayer.svelte
@@ -136,7 +136,7 @@
 	}
 </script>
 
-<div class="fixed bottom-0 left-0 right-0 z-[80] bg-neutral-900 dark:bg-neutral-800 text-white shadow-lg select-none">
+<div class="fixed bottom-0 left-0 right-0 z-[80] bg-neutral-900 dark:bg-neutral-800 text-white shadow-lg select-none" style="padding-bottom: env(safe-area-inset-bottom, 0px)">
 	<!-- Soundfont loading overlay -->
 	{#if soundFontLoading}
 		<div class="absolute inset-x-0 top-0 z-10 bg-neutral-900/90 py-1.5">
@@ -147,7 +147,7 @@
 	<!-- Progress bar -->
 	<ProgressBar progress={state.progress} duration={state.duration} dark={true} on:seek={handleSeek} />
 
-	<div class="flex items-center px-4 py-2 gap-3">
+	<div class="flex items-center px-2 h-10 sm:h-auto sm:px-4 sm:py-2 gap-1.5 sm:gap-3 flex-nowrap overflow-hidden">
 		<!-- Play/pause -->
 		<button
 			on:click={togglePlayPause}
@@ -156,11 +156,11 @@
 			aria-label={state.playing ? 'Pause' : 'Play'}
 			disabled={soundFontLoading}
 		>
-			<i class="material-icons !text-2xl">{soundFontLoading ? 'hourglass_top' : state.playing ? 'pause' : 'play_arrow'}</i>
+			<i class="material-icons !text-xl sm:!text-2xl">{soundFontLoading ? 'hourglass_top' : state.playing ? 'pause' : 'play_arrow'}</i>
 		</button>
 
-		<!-- Artwork thumbnail -->
-		<a href="{base}/play" class="flex-shrink-0">
+		<!-- Artwork thumbnail (desktop only) -->
+		<a href="{base}/play" class="flex-shrink-0 hidden sm:block">
 			{#if artworkUrl}
 				<img src={artworkUrl} alt="" class="w-10 h-10 rounded object-cover bg-neutral-700" on:error={(e) => { if (e.target instanceof HTMLElement) e.target.style.display='none'; }} />
 			{:else}
@@ -170,35 +170,50 @@
 			{/if}
 		</a>
 
-		<!-- Title/artist -->
-		<div class="flex-1 min-w-0 text-left">
-			<a href="{base}/play" class="hover:opacity-80 transition-opacity">
-				<p class="text-sm font-medium truncate text-white">
-					{state.title || currentTab?.title || 'Now playing'}
-				</p>
-			</a>
-			<p class="text-xs text-neutral-400 truncate">
-				<span class="relative inline-block">
-					<ArtistTooltip artistName={state.artist || currentTab?.artist || ''} position="top">
-						<a
-							href="{base}/search?q={encodeURIComponent(state.artist || currentTab?.artist || '')}"
-							class="hover:text-violet-400 hover:underline transition-colors"
-							on:click|stopPropagation
-						>{state.artist || currentTab?.artist || ''}</a>
-					</ArtistTooltip>
-				</span>
+		<!-- Title/artist (tap to open player) -->
+		<a href="{base}/play" class="flex-1 min-w-0 text-left hover:opacity-80 transition-opacity">
+			<p class="text-[11px] sm:text-sm font-medium truncate text-white leading-tight">
+				{state.title || currentTab?.title || 'Now playing'}
+			</p>
+			<p class="text-[9px] sm:text-xs text-neutral-400 truncate leading-tight">
+				{state.artist || currentTab?.artist || ''}
 				{#if state.duration > 0}
-					<span class="text-neutral-500"> &middot; {currentTime} / {totalTime}</span>
+					<span class="text-neutral-500">&middot; {currentTime}/{totalTime}</span>
 				{/if}
 			</p>
-		</div>
+		</a>
 
-		<!-- Source variant switcher -->
+		<!-- Audio source toggle (compact on mobile) -->
+		{#if $activeVideoId}
+			<button
+				on:click={toggleSource}
+				class="flex-shrink-0 p-1 rounded transition-colors {$audioSource === 'video' ? 'text-violet-400' : 'text-neutral-500 hover:text-white'}"
+				title="{$audioSource === 'video' ? 'Video audio' : 'Tab audio'}"
+			>
+				<i class="material-icons !text-base sm:!text-lg">{$audioSource === 'video' ? 'videocam' : 'music_note'}</i>
+			</button>
+			<!-- Sync offset (desktop only) -->
+			<div class="hidden sm:flex items-center gap-0.5 flex-shrink-0">
+				<button
+					on:click={() => nudgeOffset(-0.1)}
+					class="px-0.5 text-neutral-500 hover:text-white transition-colors text-[10px] font-mono"
+				>-</button>
+				<span class="text-[10px] text-neutral-400 font-mono min-w-[2rem] text-center">
+					{$videoSyncOffset > 0 ? '+' : ''}{$videoSyncOffset.toFixed(1)}s
+				</span>
+				<button
+					on:click={() => nudgeOffset(0.1)}
+					class="px-0.5 text-neutral-500 hover:text-white transition-colors text-[10px] font-mono"
+				>+</button>
+			</div>
+		{/if}
+
+		<!-- Source variants (desktop only) -->
 		{#if hasVariants}
-			<div class="flex items-center gap-1 flex-shrink-0">
+			<div class="hidden sm:flex items-center gap-1 flex-shrink-0">
 				{#each variants as variant}
 					<button
-						class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[9px] font-medium border transition-colors
+						class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[9px] font-medium border transition-colors whitespace-nowrap
 							{variant.id === (currentTab?.tabId || '')
 								? 'bg-violet-500/20 border-violet-400 text-violet-300'
 								: 'border-neutral-600 text-neutral-500 hover:text-neutral-300 hover:border-neutral-400'}"
@@ -213,33 +228,7 @@
 			</div>
 		{/if}
 
-		<!-- Audio source toggle + sync offset (when video active) -->
-		{#if $activeVideoId}
-			<div class="flex items-center gap-0.5 flex-shrink-0">
-				<button
-					on:click={toggleSource}
-					class="p-1 rounded transition-colors {$audioSource === 'video' ? 'text-violet-400' : 'text-neutral-500 hover:text-white'}"
-					title="{$audioSource === 'video' ? 'Video audio' : 'Tab audio'} - tap to switch"
-				>
-					<i class="material-icons !text-base">{$audioSource === 'video' ? 'videocam' : 'music_note'}</i>
-				</button>
-				<button
-					on:click={() => nudgeOffset(-0.1)}
-					class="px-0.5 text-neutral-500 hover:text-white transition-colors text-[10px] font-mono"
-					title="Sync -0.1s"
-				>-</button>
-				<span class="text-[10px] text-neutral-400 font-mono min-w-[2rem] text-center">
-					{$videoSyncOffset > 0 ? '+' : ''}{$videoSyncOffset.toFixed(1)}s
-				</span>
-				<button
-					on:click={() => nudgeOffset(0.1)}
-					class="px-0.5 text-neutral-500 hover:text-white transition-colors text-[10px] font-mono"
-					title="Sync +0.1s"
-				>+</button>
-			</div>
-		{/if}
-
-		<!-- Share link -->
+		<!-- Desktop-only actions -->
 		{#if currentTab?.tabId}
 			<button
 				on:click={copyShareLink}
@@ -249,8 +238,6 @@
 				<i class="material-icons !text-lg">{shareJustCopied ? 'check' : 'share'}</i>
 			</button>
 		{/if}
-
-		<!-- Open full player -->
 		<a
 			href="{base}/play"
 			class="flex-shrink-0 text-neutral-500 hover:text-white transition-colors hidden sm:block"
@@ -258,17 +245,15 @@
 		>
 			<i class="material-icons !text-lg">keyboard_arrow_up</i>
 		</a>
-
-		<!-- Toggle preview -->
 		<button
 			on:click={() => dispatch('togglePreview')}
-			class="flex-shrink-0 text-neutral-500 hover:text-white transition-colors"
+			class="flex-shrink-0 text-neutral-500 hover:text-white transition-colors hidden sm:block"
 			title="{showPreview ? 'Hide' : 'Show'} tab preview"
 		>
 			<i class="material-icons !text-lg">{showPreview ? 'picture_in_picture' : 'picture_in_picture_alt'}</i>
 		</button>
 
-		<!-- Close -->
+		<!-- Close (always visible) -->
 		<button
 			on:click={stopPlayer}
 			class="flex-shrink-0 text-neutral-500 hover:text-white transition-colors"

--- a/src/library/components/ProgressBar.svelte
+++ b/src/library/components/ProgressBar.svelte
@@ -37,6 +37,44 @@
 			showTooltip = true;
 		}
 	}
+
+	function computePctFromTouch(touch: Touch): number {
+		if (!barEl) return 0;
+		const rect = barEl.getBoundingClientRect();
+		return Math.max(0, Math.min(100, ((touch.clientX - rect.left) / rect.width) * 100));
+	}
+
+	function handleTouchStart(e: TouchEvent) {
+		if (!barEl || !e.touches[0]) return;
+		const pct = computePctFromTouch(e.touches[0]);
+		dispatch('seek', pct);
+	}
+
+	function handleTouchMove(e: TouchEvent) {
+		if (!barEl || !e.touches[0]) return;
+		const touch = e.touches[0];
+		const rect = barEl.getBoundingClientRect();
+		hoverPct = computePctFromTouch(touch);
+		hovering = true;
+		if (duration > 0) {
+			const timeSeconds = (hoverPct / 100) * (duration / 1000);
+			tooltipTime = displayTime(Math.round(timeSeconds));
+			tooltipX = Math.max(20, Math.min(rect.width - 20, touch.clientX - rect.left));
+			showTooltip = true;
+		}
+	}
+
+	function handleTouchEnd(e: TouchEvent) {
+		if (!barEl) return;
+		const lastTouch = e.changedTouches[0];
+		if (lastTouch) {
+			const pct = computePctFromTouch(lastTouch);
+			dispatch('seek', pct);
+		}
+		hovering = false;
+		hoverPct = 0;
+		showTooltip = false;
+	}
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-noninteractive-element-interactions -->
@@ -46,6 +84,9 @@
 	on:click={handleClick}
 	on:mousemove={handleHover}
 	on:mouseleave={() => { hovering = false; hoverPct = 0; showTooltip = false; }}
+	on:touchstart|preventDefault={handleTouchStart}
+	on:touchmove|preventDefault={handleTouchMove}
+	on:touchend={handleTouchEnd}
 	role="progressbar"
 	aria-valuenow={Math.round(progress)}
 	aria-valuemin={0}

--- a/src/library/components/TabViewer.svelte
+++ b/src/library/components/TabViewer.svelte
@@ -1649,7 +1649,12 @@
 		};
 		apiRef.renderStarted.on(onRenderStart);
 
-		const onRenderEnd = () => { isRendering = false; };
+		const onRenderEnd = () => {
+			isRendering = false;
+			if (loopStartBar !== null && loopEndBar !== null) {
+				updateScoreSelection();
+			}
+		};
 		apiRef.renderFinished?.on(onRenderEnd);
 
 		// SoundFont progress (might already be loaded)
@@ -1676,11 +1681,14 @@
 			try {
 				const bar1 = startBeat.voice?.bar?.masterBar?.index ?? 0;
 				const bar2 = endBeat.voice?.bar?.masterBar?.index ?? 0;
-				const startBar = Math.min(bar1, bar2);
-				const endBar = Math.max(bar1, bar2);
-				if (endBar < startBar) return;
-
-				renderOverlayForBars(startBar, endBar);
+				const sBar = Math.min(bar1, bar2);
+				const eBar = Math.max(bar1, bar2);
+				if (eBar < sBar) return;
+				// Temporarily set loop bars so updateScoreSelection renders the full UI
+				loopStartBar = sBar;
+				loopEndBar = eBar;
+				loopEnabled = true;
+				updateScoreSelection();
 			} catch {}
 		}
 
@@ -1730,13 +1738,17 @@
 			} catch {}
 		}
 
+		let mobileLoopSelecting = false;
+
 		const onBeatMouseDown = (beat: any) => {
+			if (mobileLoopSelecting) return;
 			scoreDragStartBeat = beat;
 			scoreDragging = false;
 		};
 		apiRef.beatMouseDown.on(onBeatMouseDown);
 
 		const onBeatMouseMove = (beat: any) => {
+			if (mobileLoopSelecting) return;
 			if (!scoreDragStartBeat || beat === scoreDragStartBeat) return;
 			scoreDragging = true;
 			showDragPreview(scoreDragStartBeat, beat);
@@ -1744,11 +1756,14 @@
 		apiRef.beatMouseMove.on(onBeatMouseMove);
 
 		const onBeatMouseUp = (beat: any) => {
+			if (mobileLoopSelecting) {
+				scoreDragStartBeat = null;
+				scoreDragging = false;
+				return;
+			}
+
 			if (!scoreDragging) {
-				// Single click - clear loop
-				if (loopStartBar !== null || loopEndBar !== null) {
-					clearLoopPoints();
-				}
+				// Don't clear loop on click - only via clear button or new selection
 				showSelectionPopover = false;
 			} else {
 				// Drag complete - commit the selection using bar indices
@@ -1776,6 +1791,180 @@
 			scoreDragging = false;
 		};
 		apiRef.beatMouseUp.on(onBeatMouseUp);
+
+		// --- Mobile touch loop selection ---
+		// Uses a transparent overlay with touch-action:none and CSS pointer-events
+		// toggled via @media (pointer: coarse). Desktop mouse clicks pass through.
+		{
+			const scoreHost = document.getElementById('player-host');
+			if (scoreHost) {
+				scoreHost.addEventListener('contextmenu', (e) => { e.preventDefault(); });
+
+				// Safari workaround (dnd-kit pattern)
+				window.addEventListener('touchmove', () => {}, { passive: false });
+
+				let mobileStartBar: number | null = null;
+				let autoScrollRAF: number | null = null;
+				let resizingEdge: 'start' | 'end' | null = null;
+				let touchLpTimer: ReturnType<typeof setTimeout> | null = null;
+				let touchStartX = 0, touchStartY = 0;
+				let lastX = 0, lastY = 0;
+				let scrolling = false;
+				let lastBarUpdate = 0;
+				const LONG_PRESS_MS = 300;
+				const MOVE_THRESHOLD = 15;
+				const EDGE_GRAB_THRESHOLD = 40;
+
+				function barAtClientPos(cx: number, cy: number): number | null {
+					try {
+						const lookup = api?.renderer?.boundsLookup;
+						const sh = scoreHost;
+						if (!lookup || !sh) return null;
+						const r = sh.getBoundingClientRect();
+						const beat = lookup.getBeatAtPos(cx - r.left, cy - r.top + (sh.scrollTop || 0));
+						return beat?.voice?.bar?.masterBar?.index ?? null;
+					} catch { return null; }
+				}
+
+				function getLoopEdgeAtPos(cx: number, cy: number): 'start' | 'end' | null {
+					if (loopStartBar === null || loopEndBar === null) return null;
+					try {
+						const lookup = api?.renderer?.boundsLookup;
+						if (!lookup?.staffSystems) return null;
+						const hostRect = scoreHost!.getBoundingClientRect();
+						let sX = Infinity, eX = -Infinity, sY = 0, eY = 0;
+						for (const sg of lookup.staffSystems) {
+							if (!sg.bars) continue;
+							for (const mbb of sg.bars) {
+								const b = mbb.realBounds;
+								if (!b) continue;
+								if (mbb.index === loopStartBar) { const x = hostRect.left + b.x; if (x < sX) { sX = x; sY = hostRect.top + b.y + b.h/2; } }
+								if (mbb.index === loopEndBar) { const x = hostRect.left + b.x + b.w; if (x > eX) { eX = x; eY = hostRect.top + b.y + b.h/2; } }
+							}
+						}
+						const dS = Math.sqrt((cx-sX)**2 + (cy-sY)**2);
+						const dE = Math.sqrt((cx-eX)**2 + (cy-eY)**2);
+						if (dS < EDGE_GRAB_THRESHOLD && dS < dE) return 'start';
+						if (dE < EDGE_GRAB_THRESHOLD) return 'end';
+					} catch {}
+					return null;
+				}
+
+				function startAutoScroll(clientY: number) {
+					stopAutoScroll();
+					const vh = window.innerHeight;
+					const zone = 80;
+					let speed = 0;
+					if (clientY < zone) speed = -2 * ((zone - clientY) / zone);
+					else if (clientY > vh - zone) speed = 2 * ((clientY - (vh - zone)) / zone);
+					if (Math.abs(speed) > 0.3) {
+						(document.scrollingElement || document.documentElement).scrollTop += speed;
+						autoScrollRAF = requestAnimationFrame(() => startAutoScroll(clientY));
+					}
+				}
+
+				function stopAutoScroll() {
+					if (autoScrollRAF) { cancelAnimationFrame(autoScrollRAF); autoScrollRAF = null; }
+				}
+
+				// Create overlay (CSS controls pointer-events via @media (pointer: coarse))
+				const touchOverlay = document.createElement('div');
+				touchOverlay.className = 'score-touch-overlay';
+				scoreHost.appendChild(touchOverlay);
+
+				touchOverlay.addEventListener('touchstart', (e: TouchEvent) => {
+					if (e.touches.length !== 1) return;
+					if (mobileLoopSelecting) return;
+					e.preventDefault();
+					const t = e.touches[0];
+					touchStartX = t.clientX; touchStartY = t.clientY;
+					lastX = t.clientX; lastY = t.clientY;
+					scrolling = false; resizingEdge = null;
+
+					// Check edge grab on existing loop
+					const edge = getLoopEdgeAtPos(t.clientX, t.clientY);
+					if (edge && loopStartBar !== null && loopEndBar !== null) {
+						resizingEdge = edge;
+						mobileLoopSelecting = true;
+						mobileStartBar = edge === 'start' ? loopEndBar : loopStartBar;
+						try { navigator.vibrate?.(15); } catch {}
+						return;
+					}
+
+					// Start long-press timer
+					touchLpTimer = setTimeout(() => {
+						touchLpTimer = null;
+						if (scrolling) return;
+						const bar = barAtClientPos(touchStartX, touchStartY);
+						if (bar === null) return;
+						mobileLoopSelecting = true;
+						mobileStartBar = bar;
+						loopStartBar = bar; loopEndBar = bar; loopEnabled = true;
+						updateScoreSelection();
+						try { navigator.vibrate?.(30); } catch {}
+					}, LONG_PRESS_MS);
+				}, { passive: false });
+
+				touchOverlay.addEventListener('touchmove', (e: TouchEvent) => {
+					if (!e.touches[0]) return;
+					e.preventDefault();
+					const t = e.touches[0];
+
+					if (mobileLoopSelecting) {
+						stopAutoScroll(); startAutoScroll(t.clientY);
+						const now = Date.now();
+						if (now - lastBarUpdate < 33) return;
+						lastBarUpdate = now;
+						const bar = barAtClientPos(t.clientX, t.clientY);
+						if (bar !== null && mobileStartBar !== null) {
+							loopStartBar = Math.min(mobileStartBar, bar);
+							loopEndBar = Math.max(mobileStartBar, bar);
+							updateScoreSelection();
+						}
+					} else {
+						const dx = Math.abs(t.clientX - touchStartX);
+						const dy = Math.abs(t.clientY - touchStartY);
+						if (dx > MOVE_THRESHOLD || dy > MOVE_THRESHOLD) {
+							if (touchLpTimer) { clearTimeout(touchLpTimer); touchLpTimer = null; }
+							scrolling = true;
+						}
+						if (scrolling) {
+							(document.scrollingElement || document.documentElement).scrollTop -= (t.clientY - lastY);
+						}
+					}
+					lastX = t.clientX; lastY = t.clientY;
+				}, { passive: false });
+
+				touchOverlay.addEventListener('touchend', (e: TouchEvent) => {
+					if (touchLpTimer) { clearTimeout(touchLpTimer); touchLpTimer = null; }
+					stopAutoScroll();
+					if (mobileLoopSelecting) {
+						if (loopStartBar !== null && loopEndBar !== null) loopEnabled = true;
+						mobileStartBar = null; resizingEdge = null;
+						// Re-render with full handles ([ ] brackets)
+						updateScoreSelection();
+						setTimeout(() => { mobileLoopSelecting = false; }, 400);
+					} else if (!scrolling && e.changedTouches?.[0]) {
+						// Tap: simulate click through overlay to alphaTab
+						const t = e.changedTouches[0];
+						touchOverlay.style.display = 'none';
+						const el = document.elementFromPoint(t.clientX, t.clientY);
+						touchOverlay.style.display = '';
+						if (el) {
+							el.dispatchEvent(new MouseEvent('mousedown', { clientX: t.clientX, clientY: t.clientY, bubbles: true }));
+							el.dispatchEvent(new MouseEvent('mouseup', { clientX: t.clientX, clientY: t.clientY, bubbles: true }));
+						}
+					}
+					scrolling = false;
+				});
+
+				touchOverlay.addEventListener('touchcancel', () => {
+					if (touchLpTimer) { clearTimeout(touchLpTimer); touchLpTimer = null; }
+					stopAutoScroll();
+					mobileLoopSelecting = false; mobileStartBar = null; resizingEdge = null; scrolling = false;
+				});
+			}
+		}
 
 		// MutationObserver - only watch for childList changes (NOT attributes to avoid cursor noise)
 		function setupSelectionObserver() {
@@ -3822,6 +4011,23 @@
 	}
 
 	/* On mobile, both use fixed positioning for proper z-index stacking */
+	/* Touch overlay: invisible to mouse, active on touch devices */
+	:global(.score-touch-overlay) {
+		position: absolute;
+		inset: 0;
+		z-index: 10;
+		touch-action: none;
+		-webkit-touch-callout: none;
+		user-select: none;
+		-webkit-user-select: none;
+		pointer-events: none;
+	}
+	@media (pointer: coarse) {
+		:global(.score-touch-overlay) {
+			pointer-events: auto;
+		}
+	}
+
 	@media (max-width: 639px) {
 		.mobile-video-pip {
 			bottom: 117px;
@@ -3832,6 +4038,7 @@
 			left: 0;
 			right: 0;
 			z-index: 100 !important;
+			padding-bottom: env(safe-area-inset-bottom, 0px);
 		}
 	}
 </style>

--- a/src/library/components/TabViewer.svelte
+++ b/src/library/components/TabViewer.svelte
@@ -2879,7 +2879,7 @@
 	<div
 		on:mouseenter={handleControlsEnter}
 		on:mouseleave={handleControlsLeave}
-		class="sticky bottom-0 z-[50] bg-white dark:bg-black border-t border-neutral-200 dark:border-neutral-800 transition-opacity duration-200
+		class="sticky bottom-0 z-[50] player-controls-bar bg-white dark:bg-black border-t border-neutral-200 dark:border-neutral-800 transition-opacity duration-200
 			{scoreLoaded || loadingTimedOut ? '' : 'pointer-events-none opacity-30'}
 			{isFullscreen ? 'fullscreen-controls' : ''}"
 		role="toolbar"
@@ -3203,8 +3203,8 @@
 
 	<!-- Video player (PiP position, above controls bar + settings) - hidden in fullscreen -->
 	{#if hasActiveVideo && $activeVideoId && !isFullscreen}
-		<div class="fixed bottom-40 right-4 z-[75] rounded-xl overflow-hidden shadow-2xl border border-neutral-200 dark:border-neutral-700 bg-black">
-			<div class="relative">
+		<div class="fixed left-0 right-0 sm:bottom-40 sm:left-auto sm:right-4 sm:w-[340px] z-[49] sm:z-[75] sm:rounded-xl overflow-hidden shadow-2xl sm:border border-neutral-200 dark:border-neutral-700 bg-black video-pip mobile-video-pip">
+			<div class="relative aspect-video">
 				<VideoPlayer
 					videoId={$activeVideoId}
 					width={340}
@@ -3315,11 +3315,11 @@
 
 	<!-- Metadata row (title, artist, actions) - hidden in fullscreen -->
 	{#if scoreLoaded && !isFullscreen}
-		<div class="px-4 py-3 border-t border-neutral-100 dark:border-neutral-800">
-			<div class="flex items-start justify-between gap-4">
-				<!-- Album artwork or artist image -->
+		<div class="px-2 py-1.5 sm:px-4 sm:py-3 border-t border-neutral-100 dark:border-neutral-800">
+			<div class="flex items-center sm:items-start justify-between gap-2 sm:gap-4">
+				<!-- Album artwork or artist image (hidden on mobile) -->
 				{#if songArtwork || artistImage}
-					<div class="flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-800">
+					<div class="flex-shrink-0 w-8 h-8 sm:w-12 sm:h-12 rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-800">
 						<img
 							src={songArtwork || artistImage}
 							alt=""
@@ -3329,8 +3329,8 @@
 					</div>
 				{/if}
 				<div class="min-w-0 flex-1">
-					<h1 class="text-lg font-semibold text-neutral-900 dark:text-neutral-100 truncate">{title.split(' - ')[0] || title}</h1>
-					<p class="text-sm text-neutral-500 dark:text-neutral-400 truncate">
+					<h1 class="text-sm sm:text-lg font-semibold text-neutral-900 dark:text-neutral-100 truncate">{title.split(' - ')[0] || title}</h1>
+					<p class="text-xs sm:text-sm text-neutral-500 dark:text-neutral-400 truncate">
 						{#if currentArtistName}
 							<span class="relative inline-block">
 								<ArtistTooltip artistName={currentArtistName} position="bottom">
@@ -3346,7 +3346,7 @@
 						{tracks[activeTrackIndex]?.name || 'Track'}{totalBars > 0 ? ` \u00B7 ${totalBars} bars` : ''}
 					</p>
 					{#if artistInfo?.tags && artistInfo.tags.length > 0}
-						<div class="flex items-center gap-1.5 mt-1 flex-wrap">
+						<div class="hidden sm:flex items-center gap-1.5 mt-1 flex-wrap">
 							{#if artistInfo.country}
 								<span class="text-[11px] text-neutral-400 dark:text-neutral-500">{artistInfo.country}</span>
 								<span class="text-neutral-300 dark:text-neutral-600">&middot;</span>
@@ -3809,3 +3809,29 @@
 		</div>
 	{/if}
 </div>
+
+
+<style>
+	/* Make YouTube iframe fill container on mobile */
+	.video-pip :global(iframe) {
+		width: 100% !important;
+		height: 100% !important;
+		position: absolute;
+		top: 0;
+		left: 0;
+	}
+
+	/* On mobile, both use fixed positioning for proper z-index stacking */
+	@media (max-width: 639px) {
+		.mobile-video-pip {
+			bottom: 117px;
+		}
+		.player-controls-bar {
+			position: fixed !important;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			z-index: 100 !important;
+		}
+	}
+</style>

--- a/src/library/styles/app.css
+++ b/src/library/styles/app.css
@@ -7,6 +7,8 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
   }
 
   .dark *:focus-visible {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -433,7 +433,7 @@
 		{/if}
 	</div>
 
-	<main id="main-content" class="animate-fade-in min-h-screen {showMiniPlayer ? (miniPreviewVisible ? 'pb-[272px] sm:pb-14' : 'pb-14') : ''}">
+	<main id="main-content" class="animate-fade-in min-h-screen {showMiniPlayer ? (miniPreviewVisible ? 'pb-11 sm:pb-[272px]' : 'pb-11 sm:pb-14') : ''}">
 		<slot />
 	</main>
 
@@ -447,7 +447,7 @@
 
 	<!-- Toast notifications -->
 	{#if $toastStore.length > 0}
-		<div class="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-[500] flex flex-col items-center gap-2 pointer-events-none">
+		<div class="fixed bottom-16 sm:bottom-4 left-1/2 transform -translate-x-1/2 z-[500] flex flex-col items-center gap-2 pointer-events-none">
 			{#each $toastStore as toast (toast.id)}
 				<div
 					class="pointer-events-auto px-4 py-2 rounded-lg shadow-lg text-sm font-medium animate-fade-in flex items-center gap-2
@@ -479,8 +479,9 @@
 		height: 600px;
 	}
 
-	/* Wrapper for mini player + overlay */
+	/* Wrapper for mini player + overlay (hidden on mobile) */
 	.mini-player-wrapper {
+		display: none;
 		position: fixed;
 		bottom: 52px;
 		right: 8px;
@@ -488,6 +489,12 @@
 		height: 220px;
 		z-index: 85;
 		cursor: pointer;
+	}
+
+	@media (min-width: 640px) {
+		.mini-player-wrapper {
+			display: block;
+		}
 	}
 
 	/* Overlay covers the wrapper exactly */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -48,7 +48,7 @@
 
 <Header on:search={handleSearch} on:openTab={handleOpenTab} />
 
-<div class="max-w-4xl mx-auto px-4 min-h-[calc(100vh-3.5rem)]">
+<div class="max-w-4xl mx-auto px-3 sm:px-4 min-h-[calc(100vh-3.5rem)]">
 	<HomeFeed {openTab} />
 </div>
 

--- a/src/routes/collection/+page.svelte
+++ b/src/routes/collection/+page.svelte
@@ -307,7 +307,7 @@
 
 	{#if activeTab === 'favorites'}
 		<!-- ==================== FAVORITES TAB - SIDE BY SIDE ==================== -->
-		<div class="grid grid-cols-1 lg:grid-cols-3 gap-4" transition:fade={{ duration: 150 }}>
+		<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 min-h-[400px]" transition:fade={{ duration: 150 }}>
 			<!-- LEFT COLUMN (2/3 width) -->
 			<div class="lg:col-span-2 space-y-6">
 				<!-- Favorite Artists (horizontal scroll) -->
@@ -474,7 +474,7 @@
 
 	{:else if activeTab === 'history'}
 		<!-- ==================== HISTORY TAB - GROUPED BY DAY ==================== -->
-		<div transition:fade={{ duration: 150 }}>
+		<div class="min-h-[300px]" transition:fade={{ duration: 150 }}>
 			<div class="flex items-center justify-between mb-3">
 				<h2 class="text-sm font-semibold text-neutral-700 dark:text-neutral-300 flex items-center gap-2">
 					<i class="material-icons !text-lg text-neutral-400">history</i>
@@ -536,7 +536,7 @@
 
 	{:else if activeTab === 'settings'}
 		<!-- ==================== SETTINGS TAB ==================== -->
-		<div class="overflow-x-hidden" transition:fade={{ duration: 150 }}>
+		<div class="overflow-x-hidden min-h-[600px]" transition:fade={{ duration: 150 }}>
 
 			<!-- ===== AUDIO SECTION ===== -->
 			<div class="flex items-center gap-2 mb-3 mt-0">
@@ -545,7 +545,7 @@
 			</div>
 
 			<!-- Sound Font - card selector (full width) -->
-			<div class="p-3 sm:p-4 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 mb-3">
+			<div class="p-3 sm:p-4 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 mb-3 min-h-[200px]">
 				<label class="text-sm font-medium text-neutral-700 dark:text-neutral-200">Sound Font</label>
 				<p class="text-[11px] text-neutral-400 dark:text-neutral-500 mt-0.5 mb-2">Choose a sound font for MIDI playback</p>
 				<div class="grid grid-cols-1 sm:grid-cols-2 gap-2">

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -502,7 +502,7 @@
 	</div>
 {/if}
 
-<div class="max-w-4xl mx-auto px-4 min-h-[calc(100vh-3.5rem)]">
+<div class="max-w-4xl mx-auto px-3 sm:px-4 min-h-[calc(100vh-3.5rem)]">
 	{#if loading && currentPage === 1 && !tabs.length}
 		<!-- Loading -->
 		<div class="flex items-center justify-center h-[calc(100vh-3.5rem)]">
@@ -525,9 +525,9 @@
 	{:else if tabs.length > 0}
 		<!-- Artist hero cards (when search matches artists) -->
 		{#if artistHeroes.length > 0}
-			<div class="flex gap-3 overflow-x-auto scroll-smooth snap-x snap-mandatory py-3 px-1 scrollbar-thin scrollbar-thumb-neutral-300 dark:scrollbar-thumb-neutral-600">
+			<div class="flex gap-3 overflow-x-auto scroll-smooth snap-x snap-mandatory py-3 px-1 scrollbar-thin scrollbar-thumb-neutral-300 dark:scrollbar-thumb-neutral-600 min-h-[140px]">
 				{#each artistHeroes as hero}
-					<div class="flex-shrink-0 snap-start w-[260px] sm:w-[300px] rounded-xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 overflow-hidden">
+					<div class="flex-shrink-0 snap-start w-[220px] sm:w-[260px] md:w-[300px] rounded-xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 overflow-hidden">
 						<!-- Top: image + name + follow -->
 						<button
 							class="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors"


### PR DESCRIPTION
- MiniPlayer: compact single-row layout on mobile (40px height), hide variants/sync/preview/share, safe-area-inset padding
- TabViewer: hide genre tags and shrink metadata on mobile, video PiP full-width above controls bar on mobile with proper z-index stacking (controls bar fixed z-100 on mobile)
- ProgressBar: add touch event support for mobile seek
- Layout: hide mini player preview on mobile, fix bottom padding, toast notifications above mini player bar
- HomeFeed/search/collection: min-height on sections to prevent layout shift, tighter padding on mobile
- app.d.ts: add play() to Api type

Closes #123, #124, #126